### PR TITLE
2.0へのレビュー & 修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,16 @@ DerivedData
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+project.xcworkspace
 
 ## Other
+.DS_Store
 *.xccheckout
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+*.swp
+doc
 
 ## Obj-C/Swift specific
 *.hmap
@@ -65,6 +69,3 @@ examples/SoraApp/Carthage/Checkouts
 fastlane/report.xml
 fastlane/screenshots
 
-*.swp
-doc
-project.xcworkspace

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -10,9 +10,12 @@ public enum SoraError: Error {
 
 public class Sora {
     
-    static var isInitialized: Bool = false
+    private static let isInitialized: Bool = {
+        initialize()
+        return true
+    }()
     
-    public static func initialize() {
+    private static func initialize() {
         RTCInitializeSSL()
         RTCEnableMetrics()
     }
@@ -21,26 +24,36 @@ public class Sora {
         RTCCleanupSSL()
     }
     
-    public static var shared: Sora = {
-        if !isInitialized {
-            initialize()
-            isInitialized = true
-        }
-        return Sora()
-    }()
+    public static let shared: Sora = Sora()
     
-    public var webRTCInfo: WebRTCInfo? = WebRTCInfo.load()
-
+    // TODO: This is most likely can be non-optional value: `load()` only returns `nil` when the bundle is severly broken
+    public let webRTCInfo: WebRTCInfo? = WebRTCInfo.load()
     
     public init() {
-        // TODO
+        // This will guarantee that `Sora.initialize()` is called only once.
+        // - It works even if user initialized `Sora` directly
+        // - It works even if user directly use `Sora.shared`
+        // - It guarantees `initialize()` is called only once thanks to the `static let` https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Properties.html#//apple_ref/doc/uid/TP40014097-CH14-ID254
+        let initialized = Sora.isInitialized
+        // This looks silly, but this will ensure `Sora.isInitialized` is not be omitted,
+        // no matter how clang optimizes compilation.
+        // If we go for `let _ = Sora.isInitialized`, clang may omit this line,
+        // which is fatal to the initialization logic.
+        // The following line will NEVER fail.
+        if !initialized { fatalError() }
     }
     
     public func connect(configuration: Configuration,
                         handler: @escaping (MediaChannel?, Error?) -> Void) {
         Log.debug(type: .sora, message: "connecting \(configuration.url.absoluteString)")
         let mediaChan = MediaChannel(configuration: configuration)
-        mediaChan.connect { handler(mediaChan, $0) }
+        mediaChan.connect { error in
+            if let error = error {
+                handler(nil, error)
+            } else {
+                handler(mediaChan, nil)
+            }
+        }
     }
     
 }

--- a/Sora/WebRTCInfo.swift
+++ b/Sora/WebRTCInfo.swift
@@ -25,11 +25,7 @@ public struct WebRTCInfo {
     public var revision: String = "Unknown"
     
     public var shortRevision: String {
-        get {
-            return revision.substring(to:
-                revision.index(revision.startIndex,
-                                     offsetBy: 7))
-        }
+        return String(revision[revision.index(revision.startIndex, offsetBy: 7)])
     }
 
 }

--- a/Sora/WebRTCInfo.swift
+++ b/Sora/WebRTCInfo.swift
@@ -21,17 +21,17 @@ public struct WebRTCInfo {
         }
     }
     
-    public var version: String = "Unknown"
-    public var revision: String = "Unknown"
+    public let version: String
+    public let revision: String
     
     public var shortRevision: String {
         return String(revision[revision.index(revision.startIndex, offsetBy: 7)])
     }
-
+    
 }
 
 extension WebRTCInfo: Decodable {
- 
+    
     enum CodingKeys: String, CodingKey {
         case version = "webrtc_version"
         case revision = "webrtc_revision"


### PR DESCRIPTION
とりま以下の箇所のみレビューして、修正できる箇所は修正しました

- Sora.swift
- Configuration.swift
- MediaChannel.swift
- WebRTCInfo.swift

またあまりにも変更が巨大になるため直接修正していませんが、以下の箇所については修正を行いたいです。

- Configuration.swiftを複数ファイルに分割（宣言されているEnum一つにつき１ファイル作っていいと思います）
- Configurationをclassからstructに変更
  - Configurationはまさに典型的なstruct向きのデータ構造で、一度最初にセットアップしたら変更する必要は基本的になく（例外としてConfigurationViewControllerがあるが、これも今の実装を見る限り大丈夫なように作ってある）、またConfigurationを他の箇所にプロパティや関数経由などで受け渡したときに受け渡し先でConfigurationの値を書き換えるようなことがあったら元の箇所に反映されてほしいかほしくないか？を考えたとき、基本的には元の箇所に反映されないほうが安全であると考えられるタイプのデータであるため。
- MediaChannelをopenからpublicに（MediaChannelをSDKユーザーが継承して何かする必要性が本当に有るか？と言われると無いように思えます。継承しなければできないことと言えば主に既存メソッドのロジックの書き換えですが、きちんとコールバックタイミングが複数設けてありますし必要な状態やデータは外部にpublicで公開されているので継承が必要になることはないと思います、包含関係で問題なく機能すると思います）
- Callback系クラスの全面廃止
  - 現状の実装だとCallback.execute()だけをprivateにして隠すのが極めて難しく、ユーザーが自分で勝手にコールバックを外部からexecute()できてしまって問題が発生します。これが一番の問題です
  - throwする実装とthrowしない実装がありますがぱっとみた感じあまりうまく機能している用に見えません、throwする実装だけをrethrowsで用意すれば良い気がしています
  - Callback1, Callback2, Callback3・・・のようなJavaっぽい感じのが必要になってしまっています
  - repeatsには意味がある用に見えますが、repeats=falseに相当する場合はcallbackを実行した後に参照をnil代入するようにすれば対応可能なので、それだけのために vクラスの採用はしたくないという感じです
- コールバックハンドラのセットの仕方をfuncからvarに変更

```
// before
public func onFailure(handler: @escaping (Error) -> Void) {
    onFailureHandler.onExecute(handler: handler)
}

// after
public var onFailureHandler: ((Error) -> Void)?

// Usage Example: Before
// Set
mediaChannel.handlers.onFailure { error in
  NSLog(error)
}
// Reset - Looks different from Set!
mediaChannel.handlers.onFailure(nil)

// Usage Example: After
// Set
mediaChannel.handlers.onFailureHandler = { error in
  NSLog(error)
}
// Reset - Looks exactly same to Set
mediaChannel.handlers.onFailureHandler = nil
```

afterの実装のほうがリセットをシンプルにできますし、他のSwiftライブラリでも一般的に見られる実装です。rethrowsの定義も個別にできます。さらにこれによりCallbackクラスのrepeatsが必要になる理由が減ります。