### PR TITLE
VideoCodec, AudioCodecを選択するとSoraへの接続に失敗する問題を修正

### DIFF
--- a/Sora/AudioCodec.swift
+++ b/Sora/AudioCodec.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-private var descriptionTable: PairTable<String, AudioCodec> =
+private let descriptionTable: PairTable<String, AudioCodec> =
     PairTable(pairs: [("default", .default),
-                      ("opus", .opus),
-                      ("pcmu", .pcmu)])
+                      ("OPUS", .opus),
+                      ("PCMU", .pcmu)])
 
 /**
  音声コーデックを表します。

--- a/Sora/VideoCodec.swift
+++ b/Sora/VideoCodec.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-private var descriptionTable: PairTable<String, VideoCodec> =
+private let descriptionTable: PairTable<String, VideoCodec> =
     PairTable(pairs: [("default", .default),
-                      ("vp8", .vp8),
-                      ("vp9", .vp9),
-                      ("h264", .h264)])
+                      ("VP8", .vp8),
+                      ("VP9", .vp9),
+                      ("H264", .h264)])
 
 /**
  映像コーデックを表します。


### PR DESCRIPTION
message変換時に使われているリテラルが小文字になっていて仕様に合っていないためエラーになっている。

仕様元参照:

- https://sora.shiguredo.jp/doc/SIGNALING.html#id5
- https://sora.shiguredo.jp/doc/SIGNALING.html#id7