### PR TITLE
VideoView の接続解除検知機能の追加

### DIFF
--- a/Sora/MediaStream.swift
+++ b/Sora/MediaStream.swift
@@ -104,6 +104,11 @@ public protocol MediaStream: class {
      */
     func send(videoFrame: VideoFrame?)
     
+    // MARK: 終了処理
+    
+    /**
+     ストリームの終了処理を行います。
+     */
     func terminate()
     
 }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -326,6 +326,9 @@ class BasicPeerChannel: PeerChannel {
     }
     
     fileprivate func terminateAllStreams() {
+        for stream in streams {
+            stream.terminate()
+        }
         streams.removeAll()
         // Do not call `handlers.onRemoveStreamHandler` here
         // This method is meant to be called only when disconnection cleanup
@@ -495,7 +498,8 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                                          audioTrackId:
                 configuration.audioEnabled ? configuration.publisherAudioTrackId : nil,
                                          constraints: webRTCConfiguration.constraints)
-        let stream = BasicMediaStream(nativeStream: nativeStream)
+        let stream = BasicMediaStream(peerChannel: channel,
+                                      nativeStream: nativeStream)
         if configuration.videoEnabled {
             switch configuration.videoCapturerDevice {
             case .camera(let settings):
@@ -767,7 +771,8 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             }
         }
         
-        let stream = BasicMediaStream(nativeStream: stream)
+        let stream = BasicMediaStream(peerChannel: self.channel,
+                                      nativeStream: stream)
         channel.add(stream: stream)
     }
     

--- a/Sora/VideoRenderer.swift
+++ b/Sora/VideoRenderer.swift
@@ -20,6 +20,41 @@ public protocol VideoRenderer: class {
      */
     func render(videoFrame: VideoFrame?)
     
+    /**
+     接続解除時に呼ばれます。
+     
+     - parameter from: 接続解除するピアチャネル
+     */
+    func onDisconnect(from: PeerChannel)
+    
+    /**
+     ストリームへの追加時に呼ばれます。
+     
+     - parameter from: 追加されるストリーム
+     */
+    func onAdded(from: MediaStream)
+    
+    /**
+     ストリームからの除去時に呼ばれます。
+     
+     - parameter from: 除去されるストリーム
+     */
+    func onRemoved(from: MediaStream)
+    
+    /**
+     映像の可否の設定の変更時に呼ばれます。
+     
+     - parameter video: 映像の可否
+     */
+    func onSwitch(video: Bool)
+    
+    /**
+     音声の可否の設定の変更時に呼ばれます。
+     
+     - parameter audio: 音声の可否
+     */
+    func onSwitch(audio: Bool)
+    
 }
 
 class VideoRendererAdapter: NSObject, RTCVideoRenderer {

--- a/Sora/VideoView.swift
+++ b/Sora/VideoView.swift
@@ -2,6 +2,22 @@ import UIKit
 import WebRTC
 
 /**
+ VideoView における、映像ソースの停止時の処理を表します。
+ */
+public enum VideoViewConnectionMode {
+    
+    /// サーバー及びストリームとの接続解除時に描画処理を停止します。
+    case auto
+    
+    /// サーバー及びストリームとの接続解除時に描画処理を停止し、 ``clear()`` を実行します。
+    case autoClear
+    
+    /// サーバー及びストリームと接続が解除されても描画処理を停止しません。
+    case manual
+    
+}
+
+/**
  VideoRenderer プロトコルのデフォルト実装となる UIView です。
  
  MediaStream.videoRenderer にセットすることで、その MediaStream
@@ -75,7 +91,37 @@ public class VideoView: UIView {
         contentView.frame = self.bounds
     }
     
-    // MARK: - 映像フレーム
+    // MARK: - 映像の描画
+    
+    /// 映像ソース停止時の処理
+    public var connectionMode: VideoViewConnectionMode = .autoClear
+    
+    /// 描画処理の実行中であれば ``true``
+    public private(set) var isRendering: Bool = false
+    
+    /// 描画停止時に ``clear()`` を実行すると表示されるビュー
+    public var backgroundView: UIView? {
+        didSet {
+            if let view = oldValue {
+                view.removeFromSuperview()
+            }
+            if let view = backgroundView {
+                addSubview(view)
+            }
+        }
+    }
+    
+    // backgroundView の未設定時、 clear() を実行すると表示される黒画面のビュー
+    private lazy var defaultBackgroundView: UIView = {
+        let view = UIView(frame: CGRect(x: 0,
+                                        y: 0,
+                                        width: self.frame.width,
+                                        height: self.frame.height))
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.backgroundColor = UIColor.black
+        self.addSubview(view)
+        return view
+    }()
     
     /**
      現在 VideoView が表示している映像の元々のフレームサイズを返します。
@@ -99,13 +145,50 @@ public class VideoView: UIView {
         return contentView.currentVideoFrameSize
     }
     
+    /**
+     画面を ``backgroundView`` のビューに切り替えます。
+     ``backgroundView`` が指定されていなければ画面を黒で塗り潰します。
+     このメソッドは描画停止時のみ有効です。
+     */
+    public func clear() {
+        if !isRendering {
+            DispatchQueue.main.async {
+                if let bgView = self.backgroundView {
+                    self.bringSubview(toFront: bgView)
+                } else {
+                    self.bringSubview(toFront: self.defaultBackgroundView)
+                }
+            }
+        }
+    }
+    
+    /**
+     映像フレームの描画を開始します。
+     */
+    public func start() {
+        if !isRendering {
+            DispatchQueue.main.async {
+                self.bringSubview(toFront: self.contentView)
+                self.isRendering = true
+            }
+        }
+    }
+    
+    /**
+     映像フレームの描画を停止します。
+     描画の停止中は ``render(videoFrame:)`` が実行されません。
+     */
+    public func stop() {
+        self.isRendering = false
+    }
+    
 }
 
 // MARK: - VideoRenderer
 
 /// :nodoc:
 extension VideoView: VideoRenderer {
-    
+
     /// :nodoc:
     public func onChange(size: CGSize) {
         contentView.onVideoFrameSizeUpdated(size)
@@ -113,7 +196,46 @@ extension VideoView: VideoRenderer {
     
     /// :nodoc:
     public func render(videoFrame: VideoFrame?) {
-        contentView.render(videoFrame: videoFrame)
+        if isRendering {
+            contentView.render(videoFrame: videoFrame)
+        }
+    }
+    
+    private func autoStop() {
+        switch connectionMode {
+        case .auto:
+            stop()
+        case .autoClear:
+            stop()
+            clear()
+        case .manual:
+            break
+        }
+    }
+    
+    public func onDisconnect(from: PeerChannel) {
+        autoStop()
+    }
+    
+    public func onAdded(from: MediaStream) {
+        switch connectionMode {
+        case .auto, .autoClear:
+            start()
+        case .manual:
+            break
+        }
+    }
+    
+    public func onRemoved(from: MediaStream) {
+        autoStop()
+    }
+    
+    public func onSwitch(video: Bool) {
+        autoStop()
+    }
+    
+    public func onSwitch(audio: Bool) {
+        // 何もしない
     }
     
 }


### PR DESCRIPTION
VideoView に PeerChannel または MediaStream の接続解除を検知する機能を追加しました。

- VideoRenderer
    - PeerChannel の接続解除時に呼ばれるメソッドを追加する
    - MediaStream への追加・除去時に呼ばれるメソッドを追加する
- VideoView
    - 映像停止時に表示する背景ビューを指定できるようにする。デフォルトでは黒画面を表示する
    - 接続解除時に背景ビューを自動的に切り替えるモード (VideoViewConnectionMode) を追加する