### PR TITLE
VideoCapturerHandlersをライブラリ外でインスタンス化可能にする

### DIFF
--- a/Sora/VideoCapturer.swift
+++ b/Sora/VideoCapturer.swift
@@ -16,7 +16,8 @@ public final class VideoCapturerHandlers {
     
     /// 映像フレームの生成時に呼ばれるクロージャー
     public var onCapture: ((VideoFrame) -> Void)?
-    
+
+    public init() {}
 }
 
 /**


### PR DESCRIPTION
暗黙的に生成されるinitのアクセスレベルはinternalなので明示的に宣言しないとライブラリ外でインスタンスを生成できません。

そのため現在VideoCapturerに準拠した独自実装クラスをライブラリ外で作成することが出来ません。

本PRはその事象を修正します。