### PR TITLE
Application Extension で安全な API のみを要求する

### DIFF
--- a/Sora.xcodeproj/project.pbxproj
+++ b/Sora.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		38DE16D225B16AA7007C23D8 /* CameraVideoCapturerDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38DE16D125B16AA7007C23D8 /* CameraVideoCapturerDevice.swift */; };
 		9100904E1E58B4470099E00E /* VideoView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9100904D1E58B4470099E00E /* VideoView.xib */; };
 		910090501E58B5450099E00E /* VideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9100904F1E58B5450099E00E /* VideoView.swift */; };
 		9106C27E1F31A3470019E3C7 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9106C27D1F31A3470019E3C7 /* Logger.swift */; };
@@ -75,6 +76,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		38DE16D125B16AA7007C23D8 /* CameraVideoCapturerDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraVideoCapturerDevice.swift; sourceTree = "<group>"; };
 		9100904D1E58B4470099E00E /* VideoView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VideoView.xib; sourceTree = "<group>"; };
 		9100904F1E58B5450099E00E /* VideoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoView.swift; sourceTree = "<group>"; };
 		910444CE253EC6F400EA06BE /* AudioMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMode.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				910444CE253EC6F400EA06BE /* AudioMode.swift */,
 				9174A89A1F73F9EE00D586C4 /* CameraPosition.swift */,
 				915CEC8F1F821A90006E45E2 /* CameraVideoCapturer.swift */,
+				38DE16D125B16AA7007C23D8 /* CameraVideoCapturerDevice.swift */,
 				9173595D1F2CCEBF00806F8B /* Configuration.swift */,
 				91756E201F90A87500B70C53 /* ConnectionState.swift */,
 				9141AB631F4204C0007C4D1C /* ConnectionTimer.swift */,
@@ -390,6 +393,7 @@
 				916134DD1F7B5EFF00ABDDAF /* AspectRatio.swift in Sources */,
 				9174A8951F73F90B00D586C4 /* AudioCodec.swift in Sources */,
 				91A19B8A1F19366000A76852 /* SignalingChannel.swift in Sources */,
+				38DE16D225B16AA7007C23D8 /* CameraVideoCapturerDevice.swift in Sources */,
 				918A38F81F30F49500D047BA /* ICEServerInfo.swift in Sources */,
 				916BBF721F19EF5800846166 /* ICECandidate.swift in Sources */,
 				91756E211F90A87500B70C53 /* ConnectionState.swift in Sources */,
@@ -564,6 +568,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E468BA3260AB17F9220A5002 /* Pods-Sora.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -598,6 +603,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6523F57BC3EF8964AFA55070 /* Pods-Sora.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -3,7 +3,7 @@ import WebRTC
 
 /**
  デバイスのカメラを利用した `VideoCapturer` のデフォルト実装です。
- `Configuration` の `videoCapturerDevice` に `.camera(settings:)` を
+ `Configuration` の `videoCapturerDevice` に `CameraVideoCapturerDevice` を
  指定すると、この実装が映像キャプチャーとして使用されます。
  
  カメラはパブリッシャーまたはグループの接続時に自動的に起動 (起動済みなら再起動) されます。
@@ -14,6 +14,7 @@ import WebRTC
  カメラの設定を変更したい場合は、一旦カメラを停止 `stop()` してから
  `settings` プロパティに新しい設定をセットし、カメラを再起動 `start()` します。
  */
+@available(iOSApplicationExtension, unavailable)
 public final class CameraVideoCapturer: VideoCapturer {
     
     // MARK: インスタンスの取得
@@ -214,6 +215,7 @@ public final class CameraVideoCapturer: VideoCapturer {
 
 // MARK: -
 
+@available(iOSApplicationExtension, unavailable)
 public extension CameraVideoCapturer {
     
     /**
@@ -312,6 +314,7 @@ public extension CameraVideoCapturer {
 
 // MARK: -
 
+@available(iOSApplicationExtension, unavailable)
 private class CameraVideoCapturerDelegate: NSObject, RTCVideoCapturerDelegate {
     
     weak var cameraVideoCapturer: CameraVideoCapturer!
@@ -331,6 +334,7 @@ private class CameraVideoCapturerDelegate: NSObject, RTCVideoCapturerDelegate {
 // MARK: -
 
 /// :nodoc:
+@available(iOSApplicationExtension, unavailable)
 extension CameraVideoCapturer.Settings: Codable {
     
     enum CodingKeys: String, CodingKey {
@@ -355,6 +359,7 @@ extension CameraVideoCapturer.Settings: Codable {
     
 }
 
+@available(iOSApplicationExtension, unavailable)
 private var resolutionTable: PairTable<String, CameraVideoCapturer.Settings.Resolution> =
     PairTable(name: "CameraVideoCapturer.Settings.Resolution",
               pairs: [("qvga240p", .qvga240p),
@@ -363,6 +368,7 @@ private var resolutionTable: PairTable<String, CameraVideoCapturer.Settings.Reso
                       ("hd1080p", .hd1080p)])
 
 /// :nodoc:
+@available(iOSApplicationExtension, unavailable)
 extension CameraVideoCapturer.Settings.Resolution: Codable {
     
     public init(from decoder: Decoder) throws {

--- a/Sora/CameraVideoCapturerDevice.swift
+++ b/Sora/CameraVideoCapturerDevice.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/**
+ デバイスのカメラを利用した `VideoCapturerDevice` です。
+
+ `CameraVideoCapturerDevice` はストリームへの接続完了時、自動的にカメラを起動して映像のキャプチャと配信を開始します。
+ またストリームから切断したタイミングで自動的にカメラキャプチャを終了します。
+
+ 自動的にカメラのハンドリングを行うため、複雑な用途が必要なく、すぐに使いたい場合に便利な `VideoCapturerDevice` です。
+ */
+public struct CameraVideoCapturerDevice: VideoCapturerDevice {
+    let settings: CameraVideoCapturer.Settings
+
+    public func stream(to stream: MediaStream) {
+        // 接続処理と同時にデフォルトのCameraVideoCapturerを使用してキャプチャを開始する
+        if CameraVideoCapturer.shared.isRunning {
+            CameraVideoCapturer.shared.stop()
+        }
+        CameraVideoCapturer.shared.settings = settings
+        CameraVideoCapturer.shared.start()
+        stream.videoCapturer = CameraVideoCapturer.shared
+    }
+
+    public func terminate() {
+        if settings.canStop {
+            CameraVideoCapturer.shared.stop()
+        }
+    }
+}

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -616,21 +616,10 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         let stream = BasicMediaStream(peerChannel: channel,
                                       nativeStream: nativeStream)
         if configuration.videoEnabled {
-            switch configuration.videoCapturerDevice {
-            case .camera(let settings):
+            if let device = configuration.videoCapturerDevice {
                 Logger.debug(type: .peerChannel,
                              message: "initialize video capture device")
-                // カメラが指定されている場合は、接続処理と同時にデフォルトのCameraVideoCapturerを使用してキャプチャを開始する
-                if CameraVideoCapturer.shared.isRunning {
-                    CameraVideoCapturer.shared.stop()
-                }
-                CameraVideoCapturer.shared.settings = settings
-                CameraVideoCapturer.shared.start()
-                stream.videoCapturer = CameraVideoCapturer.shared
-            case .custom:
-                // カスタムが指定されている場合は、接続処理時には何もしない
-                // 完全にユーザーサイドにVideoCapturerの設定とマネジメントを任せる
-                break
+                device.stream(to: stream)
             }
         }
         
@@ -678,17 +667,8 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     /** `initializeSenderStream()` にて生成されたリソースを開放するための、対になるメソッドです。 */
     func terminateSenderStream() {
         if configuration.videoEnabled {
-            switch configuration.videoCapturerDevice {
-            case .camera(settings: let settings):
-                // カメラが指定されている場合は
-                // 接続時に自動的に開始したキャプチャを、切断時に自動的に停止する必要がある
-                if settings.canStop {
-                    CameraVideoCapturer.shared.stop()
-                }
-            case .custom:
-                // カスタムが指定されている場合は、切断処理時には何もしない
-                // 完全にユーザーサイドにVideoCapturerの設定とマネジメントを任せる
-                break
+            if let device = configuration.videoCapturerDevice {
+                device.terminate()
             }
         }
     }

--- a/Sora/VideoCapturerDevice.swift
+++ b/Sora/VideoCapturerDevice.swift
@@ -1,80 +1,16 @@
 import Foundation
 
 /**
- `Sora` の `Configuration` 内で使用するオプションです。
+ `Sora` の `Configuration` 内で使用するプロトコルです。
  
- `Configuration` 内で `videoEnabled` が有効になっている際に、初期値としてどの `VideoCapturer` が使用されるかを指定するオプションです。
+ `Configuration` 内で `videoEnabled` が有効になっている際に、映像の配信とその停止を行う処理を提供します。
  */
-public enum VideoCapturerDevice {
+public protocol VideoCapturerDevice {
     
-    /**
-     `CameraVideoCapturer` を `VideoCapturer` として使用します。
-     
-     このオプションが使用されている場合、 `Sora` はストリームへの接続完了時、自動的にカメラを起動して映像のキャプチャと配信を開始します。
-     またこのオプションが使用されている場合、 `Sora` はストリームから切断したタイミングで自動的にカメラキャプチャを終了します。
-     
-     SDKが自動的にカメラのハンドリングを行うため、複雑な用途が必要なく、すぐに使いたい場合に便利なオプションです。
-     */
-    case camera(settings: CameraVideoCapturer.Settings)
+    /// 映像を配信します
+    func stream(to: MediaStream)
     
-    /**
-     カスタムの実装を `VideoCapturer` として使用します。
-     
-     このオプションが使用されている場合、 `Sora` はストリームへの接続完了時に `VideoCapturer` を自動的に設定**しません**。
-     したがってこのオプションを使用する場合は、ストリームへの接続完了後、自身でストリームの `VideoCapturer` を設定しない限り、映像は配信されません。
-     またこのオプションが使用されている場合、 `Sora` はストリームから切断したタイミングに `VideoCapturer` を自動的に終了**しません**。
-     必要に応じて終了時に `VideoCapturer` を停止する処理を忘れないようにしてください。
-     
-     以下のような場合にこのオプションを利用することをおすすめします。
-     
-     - カメラ以外の映像ソースから映像のキャプチャと配信を行いたいとき。
-     - 映像のキャプチャ開始・終了タイミングを細かく調整したいとき。
-     */
-    case custom
-    
-}
-
-/// :nodoc:
-extension VideoCapturerDevice: Codable {
-    
-    enum CodingKeys: String, CodingKey {
-        case type
-        case camera
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        switch type {
-        case "camera":
-            guard container.contains(.camera) else {
-                throw DecodingError
-                    .dataCorruptedError(forKey: .camera,
-                                        in: container,
-                                        debugDescription: "no camera settings")
-            }
-            let settings = try container
-                .decode(CameraVideoCapturer.Settings.self, forKey: .camera)
-            self = .camera(settings: settings)
-        case "custom":
-            self = .custom
-        default:
-            throw DecodingError
-                .dataCorruptedError(forKey: .type,
-                                    in: container,
-                                    debugDescription: "invalid VideoCapturerDevice value: \(type)")
-        }
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .camera(let settings):
-            try container.encode("camera", forKey: .type)
-            try container.encode(settings, forKey: .camera)
-        case .custom:
-            try container.encode("custom", forKey: .type)
-        }
-    }
+    /// 映像の配信を停止します
+    func terminate()
     
 }

--- a/Sora/VideoView.swift
+++ b/Sora/VideoView.swift
@@ -34,6 +34,7 @@ public enum VideoViewConnectionMode {
  Storyboard や Interface Builder 上で設定した Content Mode の値が使用されます。
  
  */
+@available(iOSApplicationExtension, unavailable)
 public class VideoView: UIView {
     
     // キーウィンドウ外で RTCEAGLVideoView を生成すると次のエラーが発生するため、
@@ -187,6 +188,7 @@ public class VideoView: UIView {
 // MARK: - VideoRenderer
 
 /// :nodoc:
+@available(iOSApplicationExtension, unavailable)
 extension VideoView: VideoRenderer {
 
     /// :nodoc:
@@ -242,6 +244,7 @@ extension VideoView: VideoRenderer {
 
 // MARK: -
 
+@available(iOSApplicationExtension, unavailable)
 class VideoViewContentView: UIView {
     
     @IBOutlet private weak var nativeVideoView: RTCEAGLVideoView!


### PR DESCRIPTION
**破壊的変更**があります。概要は以下に記してあるので、意見、要望などがあったらおしえてください。

Application Extension で利用できない API の利用を分離し、記録することで、 Xcode の "Require Only App-Extension-Safe API" ビルドオプションを指定できるようになります。

これは、Carthage の対応が廃止された 2020.1 以降で Application Extension でこのライブラリを利用しようとした場合に特に必要とされます。CocoaPods では "Require Only App-Extension-Safe API" が指定されたターゲットが依存する pod はすべて同様の指定が行われるためです。

これには次の破壊的変更が含まれます。
- `VideoCapturerDevice` が、同様の指定を行うプロトコルと `CameraVideoCapturerDevice` という実装に分離されています。
- `Configuration.videoCapturerDevice` の型が `VideoCapturerDevice?` に変更され、初期値が `nil` になっています。
- `Configuration` と `Configuration.Spotlight` の `Codable` の実装が削除されています。