### PR TITLE
スポットライトのオプションを整理

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,13 @@
 ## develop
 
 - [CHANGE] WebRTC M88 に対応する
-  - @enm10k
-- [CHANGE] Configuration.activeSpeakerLimit を spotlightNumber に変更
-  - @enm10k
+    - @enm10k
+- [CHANGE] スポットライトのオプションを整理する
+    - @enm10k
+    - Sora のスポットライトレガシー機能を利用するための API を Sora.useSpotlightLegacy() に変更
+    - Configuration.activeSpeakerLimit を非推奨にして、 Configuration.spotlightNumber に変更
+
+
 
 ## 2020.7.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [CHANGE] WebRTC M88 に対応する
   - @enm10k
+- [CHANGE] Configuration.activeSpeakerLimit を spotlightNumber に変更
+  - @enm10k
 
 ## 2020.7.1
 

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -25,9 +25,9 @@ public struct Configuration {
         /// 無効
         case disabled
         
-        /// スポットライトレガシー機能
+        @available(*, unavailable,
+        message: "Sora のスポットライトレガシー機能を利用している場合は、 Sora.useSpotlightLegacy() を使用してください。")
         case legacy
-        
     }
     
     /// サーバーの URL
@@ -374,8 +374,6 @@ extension Configuration.Spotlight: Codable {
             self = .enabled
         case "disabled":
             self = .disabled
-        case "legacy":
-            self = .legacy
         default:
             self = .disabled
         }
@@ -385,11 +383,13 @@ extension Configuration.Spotlight: Codable {
         var container = encoder.singleValueContainer()
         switch self {
         case .enabled:
-            try container.encode("enabled")
+            if Sora.isSpotlightLegacyEnabled {
+                try container.encode("legacy")
+            } else {
+                try container.encode("enabled")
+            }
         case .disabled:
             try container.encode("disabled")
-        case .legacy:
-            try container.encode("legacy")
         }
     }
     

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -104,19 +104,31 @@ public struct Configuration {
     public var spotlightEnabled: Spotlight = .disabled
     
     /// スポットライトの対象人数
-    @available(*, deprecated, renamed: "activeSpeakerLimit",
-    message: "このプロパティは activeSpeakerLimit に置き換えられました。")
+    @available(*, deprecated, renamed: "spotlightNumber",
+    message: "このプロパティは spotlightNumber に置き換えられました。")
     public var spotlight: Int? {
         get {
-            activeSpeakerLimit
+            spotlightNumber
         }
         set {
-            activeSpeakerLimit = newValue
+            spotlightNumber = newValue
         }
     }
 
     /// スポットライトの対象人数
-    public var activeSpeakerLimit: Int?
+    @available(*, deprecated, renamed: "spotlightNumber",
+    message: "このプロパティは spotlightNumber に置き換えられました。")
+    public var activeSpeakerLimit: Int? {
+        get {
+            spotlightNumber
+        }
+        set {
+            spotlightNumber = newValue
+        }
+    }
+
+    // スポットライトの対象人数
+    public var spotlightNumber: Int?
     
     /// WebRTC に関する設定
     public var webRTCConfiguration: WebRTCConfiguration = WebRTCConfiguration()
@@ -265,7 +277,7 @@ extension Configuration: Codable {
         case simulcastEnabled
         case simulcastRid
         case spotlightEnabled
-        case activeSpeakerLimit
+        case spotlightNumber
         case webRTCConfiguration
         case signalingConnectMetadata
         case signalingConnectNotifyMetadata
@@ -301,7 +313,7 @@ extension Configuration: Codable {
         audioEnabled = try container.decode(Bool.self, forKey: .audioEnabled)
         audioBitRate = try container.decodeIfPresent(Int.self, forKey: .audioBitRate)
         spotlightEnabled = try container.decode(Spotlight.self, forKey: .spotlightEnabled)
-        activeSpeakerLimit = try container.decode(Int.self, forKey: .activeSpeakerLimit)
+        spotlightNumber = try container.decode(Int.self, forKey: .spotlightNumber)
         simulcastEnabled = try container.decode(Bool.self, forKey: .simulcastEnabled)
         simulcastRid = try container.decode(SimulcastRid.self,
                                                 forKey: .simulcastRid)
@@ -334,7 +346,7 @@ extension Configuration: Codable {
         try container.encode(audioCodec, forKey: .audioCodec)
         try container.encode(audioEnabled, forKey: .audioEnabled)
         try container.encodeIfPresent(audioBitRate, forKey: .audioBitRate)
-        try container.encodeIfPresent(activeSpeakerLimit, forKey: .activeSpeakerLimit)
+        try container.encodeIfPresent(spotlightNumber, forKey: .spotlightNumber)
         try container.encode(webRTCConfiguration, forKey: .webRTCConfiguration)
         try container.encode(publisherStreamId, forKey: .publisherStreamId)
         try container.encode(publisherVideoTrackId, forKey: .publisherVideoTrackId)

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -592,7 +592,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             audioCodec: configuration.audioCodec,
             audioBitRate: configuration.audioBitRate,
             spotlightEnabled: configuration.spotlightEnabled,
-            activeSpeakerLimit: configuration.activeSpeakerLimit,
+            spotlightNumber: configuration.spotlightNumber,
             simulcastEnabled: configuration.simulcastEnabled,
             simulcastRid: configuration.simulcastRid,
             soraClient: soraClient,

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -175,19 +175,31 @@ public struct SignalingConnect {
     public var spotlightEnabled: Configuration.Spotlight
 
     /// スポットライトの対象人数
-    @available(*, deprecated, renamed: "activeSpeakerLimit",
-    message: "このプロパティは activeSpeakerLimit に置き換えられました。")
+    @available(*, deprecated, renamed: "spotlightNumber",
+    message: "このプロパティは spotlightNumber に置き換えられました。")
     public var spotlight: Int? {
         get {
-            activeSpeakerLimit
+            spotlightNumber
         }
         set {
-            activeSpeakerLimit = newValue
+            spotlightNumber = newValue
         }
     }
 
     /// スポットライトの対象人数
-    public var activeSpeakerLimit: Int?
+    @available(*, deprecated, renamed: "spotlightNumber",
+    message: "このプロパティは spotlightNumber に置き換えられました。")
+    public var activeSpeakerLimit: Int? {
+        get {
+            spotlightNumber
+        }
+        set {
+            spotlightNumber = newValue
+        }
+    }
+
+    // スポットライトの対象人数
+    public var spotlightNumber: Int?
     
     /// サイマルキャストの可否
     public var simulcastEnabled: Bool
@@ -716,9 +728,9 @@ extension SignalingConnect: Codable {
         switch spotlightEnabled {
         case .enabled:
             try container.encode(true, forKey: .spotlight)
-            try container.encodeIfPresent(activeSpeakerLimit, forKey: .spotlight_number)
+            try container.encodeIfPresent(spotlightNumber, forKey: .spotlight_number)
         case .legacy:
-            try container.encodeIfPresent(activeSpeakerLimit, forKey: .spotlight)
+            try container.encodeIfPresent(spotlightNumber, forKey: .spotlight)
         case .disabled:
             break
         }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -727,10 +727,12 @@ extension SignalingConnect: Codable {
         
         switch spotlightEnabled {
         case .enabled:
-            try container.encode(true, forKey: .spotlight)
-            try container.encodeIfPresent(spotlightNumber, forKey: .spotlight_number)
-        case .legacy:
-            try container.encodeIfPresent(spotlightNumber, forKey: .spotlight)
+            if Sora.isSpotlightLegacyEnabled {
+                try container.encodeIfPresent(spotlightNumber, forKey: .spotlight)
+            } else {
+                try container.encode(true, forKey: .spotlight)
+                try container.encodeIfPresent(spotlightNumber, forKey: .spotlight_number)
+            }
         case .disabled:
             break
         }

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -97,6 +97,13 @@ public final class Sora {
         }
     }
     
+    // スポットライトレガシー機能を有効化する
+    @available(*, deprecated,
+    message: "Sora のスポットライトレガシー機能は 2021 年 12 月のリリースにて廃止予定です。")
+    public static func useSpotlightLegacy() {
+        isSpotlightLegacyEnabled = true
+    }
+    
     // MARK: - プロパティ
     
     /// リンクしている WebRTC フレームワークの情報。
@@ -108,6 +115,8 @@ public final class Sora {
     
     /// イベントハンドラ
     public let handlers: SoraHandlers = SoraHandlers()
+    
+    internal static var isSpotlightLegacyEnabled: Bool = false
     
     // MARK: - インスタンスの生成と取得
     


### PR DESCRIPTION
## 変更内容

- Sora のスポットライトレガシー機能を利用するための API を Sora.useSpotlightLegacy() に変更する
- Configuration.activeSpeakerLimit を spotlightNumber に変更しました
  - activeSpeakerLimit は削除せずに、 deprecated を指定しています

## 残タスク

- [x] CHANGES.md の更新

