### PR TITLE
updateOfferEncodings で scaleResolutionDownBy の設定が漏れていたので追加

### DIFF
--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1076,6 +1076,11 @@ extension RTCRtpSender {
                     oldEncoding.maxBitrateBps = NSNumber(integerLiteral: value)
                 }
                 
+                if let value = encoding.scaleResolutionDownBy {
+                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownBy: \(value))")
+                    oldEncoding.scaleResolutionDownBy = NSNumber(value: value)
+                }
+                
                 break
             }
         }


### PR DESCRIPTION
## 変更内容

- updateOfferEncodings で scaleResolutionDownBy の設定が漏れていたので追加しました
  - 修正前は、 Sora の設定ファイルで指定した scaleResolutionDownBy が iOS SDK に反映されていませんでした

## 動作確認時の Sora の設定

```
# simulcast のカスタマイズを有効化
$ grep simulcast_encodings sora-2020.3.3/etc/sora.conf
simulcast_encodings_file = etc/simulcast_encodings.json

# r0, r1 を同じ大きさに設定
$ cat sora-2020.3.3/etc/simulcast_encodings.json 
[
    {"rid": "r0", "active": true, "scaleResolutionDownBy": 2.0},
    {"rid": "r1", "active": true, "scaleResolutionDownBy": 2.0},
    {"rid": "r2", "active": true, "scaleResolutionDownBy": 1.0}
]
```
