### PR TITLE
現在の WebRTC.framework/build_info.json に含まれるバージョン文字列には "M" が含まれている

### DIFF
--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -572,7 +572,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         
         var webRTCVersion: String?
         if let info = WebRTCInfo.load() {
-            webRTCVersion = "Shiguredo-build M\(info.version) (\(info.version).\(info.commitPosition).\(info.maintenanceVersion) \(info.shortRevision))"
+            webRTCVersion = "Shiguredo-build \(info.version) (\(info.version).\(info.commitPosition).\(info.maintenanceVersion) \(info.shortRevision))"
         }
         
         let connect = SignalingConnect(


### PR DESCRIPTION
type: connect に含まれる libwebrtc のバージョン表記で、ブランチの先頭につく "M" が重複している箇所を修正します。