### PR TITLE
VideoCodec に AV1 を追加する

### DIFF
--- a/Sora/VideoCodec.swift
+++ b/Sora/VideoCodec.swift
@@ -5,7 +5,8 @@ private let descriptionTable: PairTable<String, VideoCodec> =
               pairs: [("default", .default),
                       ("VP8", .vp8),
                       ("VP9", .vp9),
-                      ("H264", .h264)])
+                      ("H264", .h264),
+                      ("AV1", .av1)])
 
 /**
  映像コーデックを表します。
@@ -27,6 +28,8 @@ public enum VideoCodec {
     /// H.264
     case h264
     
+    /// AV1
+    case av1
 }
 
 extension VideoCodec: CustomStringConvertible {


### PR DESCRIPTION
## 変更内容

- VideoCodec に AV1 を追加しました

## 動作確認

- sora-ios-sdk-quickstart から AV1 の映像を送信して Sora Labo の multi_recvonly.html で受信できることを確認しました
- Sora Labo から受信した映像を sora-ios-sdk-quickstart  では再生できませんでした
  - iPad Pro (11インチ)
  - iPad OS 14.3

Sora Labo で AV1 が受信できたこを `chrome://webrtc-internals` で確認

<img width="715" alt="スクリーンショット 2021-05-05 9 54 27" src="https://user-images.githubusercontent.com/17097142/117087818-97933b00-ad8b-11eb-82d0-1d83479a8339.png">
