### PR TITLE
VideoRenderer protocol準拠のクラスを自作する際には、SDK利用者側でDispatchQueue.main.asyncを行える

### DIFF
--- a/Sora/VideoRenderer.swift
+++ b/Sora/VideoRenderer.swift
@@ -69,9 +69,7 @@ class VideoRendererAdapter: NSObject, RTCVideoRenderer {
         if let renderer = videoRenderer {
             Logger.debug(type: .videoRenderer,
                          message: "set size \(size) for \(renderer)")
-            DispatchQueue.main.async {
-                renderer.onChange(size: size)
-            }
+            renderer.onChange(size: size)
         } else {
             Logger.debug(type: .videoRenderer,
                          message: "set size \(size) IGNORED, no renderer set")
@@ -79,16 +77,14 @@ class VideoRendererAdapter: NSObject, RTCVideoRenderer {
     }
     
     func renderFrame(_ frame: RTCVideoFrame?) {
-        DispatchQueue.main.async {
-            if let renderer = self.videoRenderer {
-                if let frame = frame {
-                    let frame = VideoFrame.native(capturer: nil, frame: frame)
-                    renderer.render(videoFrame: frame)
-                } else {
-                    renderer.render(videoFrame: nil)
-                }
-            }
-        }
+          if let renderer = self.videoRenderer {
+              if let frame = frame {
+                  let frame = VideoFrame.native(capturer: nil, frame: frame)
+                  renderer.render(videoFrame: frame)
+              } else {
+                  renderer.render(videoFrame: nil)
+              }
+          }
     }
     
 }

--- a/Sora/VideoView.swift
+++ b/Sora/VideoView.swift
@@ -191,13 +191,17 @@ extension VideoView: VideoRenderer {
 
     /// :nodoc:
     public func onChange(size: CGSize) {
-        contentView.onVideoFrameSizeUpdated(size)
+        DispatchQueue.main.async {
+          self.contentView.onVideoFrameSizeUpdated(size)
+        }
     }
     
     /// :nodoc:
     public func render(videoFrame: VideoFrame?) {
         if isRendering {
-            contentView.render(videoFrame: videoFrame)
+          DispatchQueue.main.async {
+            self.contentView.render(videoFrame: videoFrame)
+          }
         }
     }
     


### PR DESCRIPTION
■ 背景
Sora iOS SDKではVideoRenderer protocolに準拠したクラスを自作できます。
これによって、SDK利用者はフレームのレンダリングやリサイズ時に任意の処理を書くことが可能です。

一方で、VideoRendererAdapterが自作VideoRendererに対してもメインスレッド上での処理を強制してしまっています。
そのため、VideoRendererAdapter内でDispatchQueue.main.asyncをしない方が、VideoRenderer protocolを実装する側にとって、より好ましい振る舞いを実装できるのではないか、と考えました。

■ 方針
・VideoRendererAdapterではDispatchQueue.main.asyncを使わない
・DispatchQueue.main.asyncを使うかどうかはVideoRenderer protocolを実装するクラス側が判断する

■ メリット
- 本当にDispatchQueue.main.asyncが必要な部分でのみ呼び出せる
- 結果として `render()` や `onChange()` に任意の処理(判定処理など)が入った場合に VideoRenderer内のパフォーマンスが向上する

■ デメリット
- 今までVideoRendererクラスを実装していたSDK利用者は自身でキューをケアする必要が出てくる

