### PR TITLE
コメントを修正

### DIFF
--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -96,7 +96,7 @@ public struct Configuration {
     public var simulcastEnabled: Bool = false
 
     /// サイマルキャストでの映像の種類。
-    /// ロールが `.recvonly` のときのみ有効です。
+    /// ロールが `.sendrecv` または `.recvonly` のときのみ有効です。
     public var simulcastRid: SimulcastRid?
 
     /// スポットライトの可否


### PR DESCRIPTION
## 変更内容

- simulcastRid は `.sendrecv` でも有効なので、コメントを修正します
