### PR TITLE
simulcastRid が nil の場合は JSON に含めないようにする

### DIFF
--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -816,7 +816,7 @@ extension SignalingConnect: Codable {
             try container.encode(true, forKey: .simulcast)
             switch role {
             case .downstream, .sendrecv, .recvonly:
-                try container.encode(simulcastRid, forKey: .simulcast_rid)
+                try container.encodeIfPresent(simulcastRid, forKey: .simulcast_rid)
             default:
                 break
             }


### PR DESCRIPTION
Configuration で simulcastRid が nil に設定されている場合に、シグナリングの JSON に `simulcast_rid = null` が含まれる事象を修正します。 `simulcast_rid = null` が含まれているとサイマルキャスト有効時の接続に失敗します。