### PR TITLE
active: false が無効化されてしまう問題に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@
     - SignalingNotifyConnection.authzMetadata
     - SignalingNotifyConnection.data
     - @enm10k
+- [FIX] サイマルキャストのパラメーター active: false が無効化されてしまう問題を修正する
+    - @enm10k
 
 ## 2020.7.1
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -819,6 +819,10 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             let message = Signaling.update(SignalingUpdate(sdp: answer!))
             self.signalingChannel.send(message: message)
             
+            if (self.configuration.isSender) {
+                self.updateSenderOfferEncodings()
+            }
+            
             // Answer 送信後に RTCPeerConnection の状態に変化はないため、
             // Answer を送信したら更新完了とする
             self.state = .connected


### PR DESCRIPTION
## 変更内容

- createAndSendUpdateAnswer が実行されたタイミングで、 encodings の active: false が無効化されてしまう問題を修正しました