### PR TITLE
[DO NOT MERGE] SignalingConnect に clientId が漏れていたので追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## 2020.7.2
+
+- [FIX] SignalingConnect に clientId が漏れていたので追加する
+    - @enm10k
+
 ## 2020.7.1
 
 - [CHANGE] スポットライトレガシー機能に対応する

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -36,6 +36,9 @@ public struct Configuration {
     /// チャネル ID
     public var channelId: String
     
+    /// クライアント ID
+    public var clientId: String?
+    
     /// ロール
     public var role: Role
     
@@ -252,6 +255,7 @@ extension Configuration: Codable {
     enum CodingKeys: String, CodingKey {
         case url
         case channelId
+        case clientId
         case role
         case multistreamEnabled
         case metadata
@@ -283,6 +287,7 @@ extension Configuration: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let url = try container.decode(URL.self, forKey: .url)
         let channelId = try container.decode(String.self, forKey: .channelId)
+        let clientId = try container.decodeIfPresent(String.self, forKey: .clientId)
         let role = try container.decode(Role.self, forKey: .role)
         let multistreamEnabled = try container.decode(Bool.self, forKey: .multistreamEnabled)
         self.init(url: url,
@@ -322,6 +327,7 @@ extension Configuration: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(url, forKey: .url)
         try container.encode(channelId, forKey: .channelId)
+        try container.encodeIfPresent(clientId, forKey: .clientId)
         try container.encode(role, forKey: .role)
         try container.encode(simulcastEnabled, forKey: .simulcastEnabled)
         try container.encode(simulcastQuality, forKey: .simulcastQuality)

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -568,6 +568,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         let connect = SignalingConnect(
             role: role,
             channelId: configuration.channelId,
+            clientId: configuration.clientId,
             metadata: configuration.signalingConnectMetadata,
             notifyMetadata: configuration.signalingConnectNotifyMetadata,
             sdp: sdp,

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -141,6 +141,9 @@ public struct SignalingConnect {
     /// チャネル ID
     public var channelId: String
     
+    /// クライアント ID
+    public var clientId: String?
+
     /// メタデータ
     public var metadata: Encodable?
     
@@ -626,6 +629,7 @@ extension SignalingConnect: Codable {
     enum CodingKeys: String, CodingKey {
         case role
         case channel_id
+        case client_id
         case metadata
         case signaling_notify_metadata
         case sdp
@@ -662,6 +666,7 @@ extension SignalingConnect: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(role, forKey: .role)
         try container.encode(channelId, forKey: .channel_id)
+        try container.encodeIfPresent(clientId, forKey: .client_id)
         try container.encodeIfPresent(sdp, forKey: .sdp)
         let metadataEnc = container.superEncoder(forKey: .metadata)
         try metadata?.encode(to: metadataEnc)


### PR DESCRIPTION
## 注意

この PR はレビュー用です
GitHub 上でマージしないでください

## 変更内容

- SignalingConnect に clientId が漏れていたので追加しました

## 動作確認

sora-ios-sdk-quickstart を以下のように修正して Sora に接続し、 Sora の signaling.log に `client_id` が出力されることを確認しました。

```
$ git diff **.swift
@@@ -151,17 -150,27 +154,26 @@@
          }
          
          // 接続の設定を行います。
-         let config = Configuration(url: soraURL,
+         var config = Configuration(url: soraURL,
                                     channelId: soraChannelId,
                                     role: role,
                                     multistreamEnabled: multiplicityControl.selectedSegmentIndex == 1)
+         config.clientId = "クライアントID"
...
```

### 指定した client_id が connect に含まれていること

signaling.log を確認

```
{"type":"connect","channel_id":"sora","connection_id":"N4K8322CMS34ZA19PVGCTZNCBM","timestamp":"2021-05-26T00:38:13.558989Z","role":"sendrecv","json":{"channel_id":"sora","client_id":"\u30af\u30e9\u30a4\u30a2\u30f3\u30c8ID","environment":"iPad Pro 11-inch (Wi-Fi); iOS 14.5.1","libwebrtc":"Shiguredo-build MM90 (M90.3.2 dee77cf)","metadata":{},"multistream":true,"role":"sendrecv","sdp":"v=0\r\no=- 3940369886938348186 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0 1\r\na=extmap-allow-mixed\r\na=msid-semantic: WMS offer\r\nm=video 9 UDP\/TLS\/RTP\/SAVPF 96 97 98 99 100 101 127 123 35 36 125 122 124\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:Md8W\r\na=ice-pwd:cDQI5aimUW\/Cqw+wIToXaqZJ\r\na=ice-options:trickle renomination\r\na=fingerprint:sha-256 0B:52:1D:CA:69:88:80:9D:1D:C2:CC:A4:D1:B0:2F:BB:2C:49:57:EC:7E:3D:29:98:31:99:A1:C6:F2:EA:34:03\r\na=setup:actpass\r\na=mid:0\r\na=extmap:1 urn:ietf:params:rtp-hdrext:toffset\r\na=extmap:2 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time\r\na=extmap:3 urn:3gpp:video-orientation\r\na=extmap:4 http:\/\/www.ietf.org\/id\/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:5 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/playout-delay\r\na=extmap:6 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/video-content-type\r\na=extmap:7 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/video-timing\r\na=extmap:8 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/color-space\r\na=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:offer video\r\na=rtcp-mux\r\na=rtcp-rsize\r\na=rtpmap:96 H264\/90000\r\na=rtcp-fb:96 goog-remb\r\na=rtcp-fb:96 transport-cc\r\na=rtcp-fb:96 ccm fir\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c34\r\na=rtpmap:97 rtx\/90000\r\na=fmtp:97 apt=96\r\na=rtpmap:98 H264\/90000\r\na=rtcp-fb:98 goog-remb\r\na=rtcp-fb:98 transport-cc\r\na=rtcp-fb:98 ccm fir\r\na=rtcp-fb:98 nack\r\na=rtcp-fb:98 nack pli\r\na=fmtp:98 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e034\r\na=rtpmap:99 rtx\/90000\r\na=fmtp:99 apt=98\r\na=rtpmap:100 VP8\/90000\r\na=rtcp-fb:100 goog-remb\r\na=rtcp-fb:100 transport-cc\r\na=rtcp-fb:100 ccm fir\r\na=rtcp-fb:100 nack\r\na=rtcp-fb:100 nack pli\r\na=rtpmap:101 rtx\/90000\r\na=fmtp:101 apt=100\r\na=rtpmap:127 VP9\/90000\r\na=rtcp-fb:127 goog-remb\r\na=rtcp-fb:127 transport-cc\r\na=rtcp-fb:127 ccm fir\r\na=rtcp-fb:127 nack\r\na=rtcp-fb:127 nack pli\r\na=rtpmap:123 rtx\/90000\r\na=fmtp:123 apt=127\r\na=rtpmap:35 AV1X\/90000\r\na=rtcp-fb:35 goog-remb\r\na=rtcp-fb:35 transport-cc\r\na=rtcp-fb:35 ccm fir\r\na=rtcp-fb:35 nack\r\na=rtcp-fb:35 nack pli\r\na=rtpmap:36 rtx\/90000\r\na=fmtp:36 apt=35\r\na=rtpmap:125 red\/90000\r\na=rtpmap:122 rtx\/90000\r\na=fmtp:122 apt=125\r\na=rtpmap:124 ulpfec\/90000\r\na=ssrc-group:FID 2648784827 3094351939\r\na=ssrc:2648784827 cname:ZcUyClP74mMo9+jo\r\na=ssrc:2648784827 msid:offer video\r\na=ssrc:2648784827 mslabel:offer\r\na=ssrc:2648784827 label:video\r\na=ssrc:3094351939 cname:ZcUyClP74mMo9+jo\r\na=ssrc:3094351939 msid:offer video\r\na=ssrc:3094351939 mslabel:offer\r\na=ssrc:3094351939 label:video\r\nm=audio 9 UDP\/TLS\/RTP\/SAVPF 111 103 104 9 102 0 8 106 105 13 110 112 113 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:Md8W\r\na=ice-pwd:cDQI5aimUW\/Cqw+wIToXaqZJ\r\na=ice-options:trickle renomination\r\na=fingerprint:sha-256 0B:52:1D:CA:69:88:80:9D:1D:C2:CC:A4:D1:B0:2F:BB:2C:49:57:EC:7E:3D:29:98:31:99:A1:C6:F2:EA:34:03\r\na=setup:actpass\r\na=mid:1\r\na=extmap:14 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:2 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time\r\na=extmap:4 http:\/\/www.ietf.org\/id\/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:offer audio\r\na=rtcp-mux\r\na=rtpmap:111 opus\/48000\/2\r\na=rtcp-fb:111 transport-cc\r\na=fmtp:111 minptime=10;useinbandfec=1\r\na=rtpmap:103 ISAC\/16000\r\na=rtpmap:104 ISAC\/32000\r\na=rtpmap:9 G722\/8000\r\na=rtpmap:102 ILBC\/8000\r\na=rtpmap:0 PCMU\/8000\r\na=rtpmap:8 PCMA\/8000\r\na=rtpmap:106 CN\/32000\r\na=rtpmap:105 CN\/16000\r\na=rtpmap:13 CN\/8000\r\na=rtpmap:110 telephone-event\/48000\r\na=rtpmap:112 telephone-event\/32000\r\na=rtpmap:113 telephone-event\/16000\r\na=rtpmap:126 telephone-event\/8000\r\na=ssrc:772526561 cname:ZcUyClP74mMo9+jo\r\na=ssrc:772526561 msid:offer audio\r\na=ssrc:772526561 mslabel:offer\r\na=ssrc:772526561 label:audio\r\n","signaling_notify_metadata":{},"sora_client":"Sora iOS SDK 2020.7.1 (2d54b6f)","type":"connect"}}
```

### connect で指定した client_id が offer に含まれること

Xcode の出力を確認

```
...
2021-05-26 10:05:48 SignalingChannel DEBUG: connected
2021-05-26 10:05:49 WebSocketChannel DEBUG: receive message => string("{\"client_id\":\"\\u30af\\u30e9\\u30a4\\u30a2\\u30f3\\u30c8ID\",\"config\":{\"iceServers\":[...],\"iceTransportPolicy\":\"relay\"},\"connection_id\":\"JS3TFXD3ZD2P59HP3REPTAJPH8\",\"mid\":{\"audio\":\"audio_QOLQ9v\",\"video\":\"video_6uq1pb\"},\"sdp\":\"v=0\\r\\no=Shiguredo...Sora-2021.1-canary.36 4259203578931756637 0 IN IP4 0.0.0.0\\r\\ns=-\\r\\nt=0 0\\r\\na=fingerprint:sha-256 56:62:59:3A:D3:E0:12:91:FB:B7:9C:D4:38:45:53:AB:A2:C7:E4:37:F5:25:F0:96:E3:F8:A4:FF:ED:E0:46:E8\\r\\na=group:BUNDLE audio_QOLQ9v video_6uq1pb\\r\\na=extmap-allow-mixed\\r\\na=msid-semantic:WMS *\\r\\na=ice-options:trickle\\r\\nm=audio 9 UDP\\/TLS\\/RTP\\/SAVPF 109\\r\\nc=IN IP4 0.0.0.0\\r\\na=candidate:0 1 UDP 2114002687 45.32.253.245 43686 typ host\\r\\na=recvonly\\r\\na=rtcp-rsize\\r\\na=rtcp-mux\\r\\na=ice-ufrag:it4sGpLRLVkv\\r\\na=ice-pwd:XSrs0F8Szz8lSWx70tbT11koXiEgqOaFeg5c\\r\\na=mid:audio_QOLQ9v\\r\\na=msid:JS3TFXD3ZD2P59HP3REPTAJPH8 7YY39NAJQ11H94H0RRC89FSQSM\\r\\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\\r\\na=extmap:2 http:\\/\\/www.webrtc.org\\/experiments\\/rtp-hdrext\\/abs-send-time\\r\\na=extmap:11 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\\r\\na=extmap:12 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\\r\\na=rtpmap:109 opus\\/48000\\/2\\r\\na=fmtp:109 maxplaybackrate=48000;stereo=1;sprop-stereo=1;minptime=10;ptime=20;useinbandfec=1;usedtx=0\\r\\na=setup:actpass\\r\\nm=video 9 UDP\\/TLS\\/RTP\\/SAVPF 120 96\\r\\nc=IN IP4 0.0.0.0\\r\\nb=TIAS:500000\\r\\nb=AS:500\\r\\na=candidate:0 1 UDP 2114002687 45.32.253.245 43686 typ host\\r\\na=recvonly\\r\\na=rtcp-rsize\\r\\na=rtcp-mux\\r\\na=ice-ufrag:it4sGpLRLVkv\\r\\na=ice-pwd:XSrs0F8Szz8lSWx70tbT11koXiEgqOaFeg5c\\r\\na=mid:video_6uq1pb\\r\\na=msid:JS3TFXD3ZD2P59HP3REPTAJPH8 SFTS1N7AD92S53W5AK8P5EJ7Y4\\r\\na=extmap:2 http:\\/\\/www.webrtc.org\\/experiments\\/rtp-hdrext\\/abs-send-time\\r\\na=extmap:11 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\\r\\na=extmap:12 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\\r\\na=extmap:13 https:\\/\\/aomediacodec.github.io\\/av1-rtp-spec\\/#dependency-descriptor-rtp-header-extension\\r\\na=rtcp-fb:120 ccm fir\\r\\na=rtcp-fb:120 nack\\r\\na=rtcp-fb:120 nack pli\\r\\na=rtcp-fb:120 goog-remb\\r\\na=fmtp:120 x-google-start-bitrate=500\\r\\na=rtpmap:120 VP9\\/90000\\r\\na=fmtp:120 profile-id=0\\r\\na=rtpmap:96 rtx\\/90000\\r\\na=fmtp:96 apt=120\\r\\na=setup:actpass\\r\\n\",\"type\":\"offer\",\"version\":\"2021.1-canary.36\"}")

```

### client_id を指定していない場合の動作

`config.clientId` を設定している行をコメントアウトして確認

signaling.log

```
{"type":"connect","channel_id":"sora","connection_id":"DMEY2GKX3S6S38JEV8ZHA5GGRW","timestamp":"2021-05-26T00:56:24.198264Z","role":"sendrecv","json":{"channel_id":"sora","environment":"iPad Pro 11-inch (Wi-Fi); iOS 14.5.1","libwebrtc":"Shiguredo-build MM90 (M90.3.2 dee77cf)","metadata":{},"multistream":true,"role":"sendrecv","sdp":"v=0\r\no=- 9200418913727748655 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0 1\r\na=extmap-allow-mixed\r\na=msid-semantic: WMS offer\r\nm=video 9 UDP\/TLS\/RTP\/SAVPF 96 97 98 99 100 101 127 123 35 36 125 122 124\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:\/b9v\r\na=ice-pwd:TyJAh\/oom2GHBJ+N51KfwEzy\r\na=ice-options:trickle renomination\r\na=fingerprint:sha-256 B9:47:8A:28:D8:9B:AA:3F:2F:98:9A:E1:48:9F:F7:62:B8:40:3E:89:20:32:43:C5:B9:7F:96:BB:F8:83:85:93\r\na=setup:actpass\r\na=mid:0\r\na=extmap:1 urn:ietf:params:rtp-hdrext:toffset\r\na=extmap:2 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time\r\na=extmap:3 urn:3gpp:video-orientation\r\na=extmap:4 http:\/\/www.ietf.org\/id\/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:5 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/playout-delay\r\na=extmap:6 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/video-content-type\r\na=extmap:7 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/video-timing\r\na=extmap:8 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/color-space\r\na=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:offer video\r\na=rtcp-mux\r\na=rtcp-rsize\r\na=rtpmap:96 H264\/90000\r\na=rtcp-fb:96 goog-remb\r\na=rtcp-fb:96 transport-cc\r\na=rtcp-fb:96 ccm fir\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c34\r\na=rtpmap:97 rtx\/90000\r\na=fmtp:97 apt=96\r\na=rtpmap:98 H264\/90000\r\na=rtcp-fb:98 goog-remb\r\na=rtcp-fb:98 transport-cc\r\na=rtcp-fb:98 ccm fir\r\na=rtcp-fb:98 nack\r\na=rtcp-fb:98 nack pli\r\na=fmtp:98 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e034\r\na=rtpmap:99 rtx\/90000\r\na=fmtp:99 apt=98\r\na=rtpmap:100 VP8\/90000\r\na=rtcp-fb:100 goog-remb\r\na=rtcp-fb:100 transport-cc\r\na=rtcp-fb:100 ccm fir\r\na=rtcp-fb:100 nack\r\na=rtcp-fb:100 nack pli\r\na=rtpmap:101 rtx\/90000\r\na=fmtp:101 apt=100\r\na=rtpmap:127 VP9\/90000\r\na=rtcp-fb:127 goog-remb\r\na=rtcp-fb:127 transport-cc\r\na=rtcp-fb:127 ccm fir\r\na=rtcp-fb:127 nack\r\na=rtcp-fb:127 nack pli\r\na=rtpmap:123 rtx\/90000\r\na=fmtp:123 apt=127\r\na=rtpmap:35 AV1X\/90000\r\na=rtcp-fb:35 goog-remb\r\na=rtcp-fb:35 transport-cc\r\na=rtcp-fb:35 ccm fir\r\na=rtcp-fb:35 nack\r\na=rtcp-fb:35 nack pli\r\na=rtpmap:36 rtx\/90000\r\na=fmtp:36 apt=35\r\na=rtpmap:125 red\/90000\r\na=rtpmap:122 rtx\/90000\r\na=fmtp:122 apt=125\r\na=rtpmap:124 ulpfec\/90000\r\na=ssrc-group:FID 3983972308 4145347955\r\na=ssrc:3983972308 cname:LTvcWSPfz\/GAGMEn\r\na=ssrc:3983972308 msid:offer video\r\na=ssrc:3983972308 mslabel:offer\r\na=ssrc:3983972308 label:video\r\na=ssrc:4145347955 cname:LTvcWSPfz\/GAGMEn\r\na=ssrc:4145347955 msid:offer video\r\na=ssrc:4145347955 mslabel:offer\r\na=ssrc:4145347955 label:video\r\nm=audio 9 UDP\/TLS\/RTP\/SAVPF 111 103 104 9 102 0 8 106 105 13 110 112 113 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:\/b9v\r\na=ice-pwd:TyJAh\/oom2GHBJ+N51KfwEzy\r\na=ice-options:trickle renomination\r\na=fingerprint:sha-256 B9:47:8A:28:D8:9B:AA:3F:2F:98:9A:E1:48:9F:F7:62:B8:40:3E:89:20:32:43:C5:B9:7F:96:BB:F8:83:85:93\r\na=setup:actpass\r\na=mid:1\r\na=extmap:14 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:2 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time\r\na=extmap:4 http:\/\/www.ietf.org\/id\/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:offer audio\r\na=rtcp-mux\r\na=rtpmap:111 opus\/48000\/2\r\na=rtcp-fb:111 transport-cc\r\na=fmtp:111 minptime=10;useinbandfec=1\r\na=rtpmap:103 ISAC\/16000\r\na=rtpmap:104 ISAC\/32000\r\na=rtpmap:9 G722\/8000\r\na=rtpmap:102 ILBC\/8000\r\na=rtpmap:0 PCMU\/8000\r\na=rtpmap:8 PCMA\/8000\r\na=rtpmap:106 CN\/32000\r\na=rtpmap:105 CN\/16000\r\na=rtpmap:13 CN\/8000\r\na=rtpmap:110 telephone-event\/48000\r\na=rtpmap:112 telephone-event\/32000\r\na=rtpmap:113 telephone-event\/16000\r\na=rtpmap:126 telephone-event\/8000\r\na=ssrc:4019873460 cname:LTvcWSPfz\/GAGMEn\r\na=ssrc:4019873460 msid:offer audio\r\na=ssrc:4019873460 mslabel:offer\r\na=ssrc:4019873460 label:audio\r\n","signaling_notify_metadata":{},"sora_client":"Sora iOS SDK 2020.7.1 (2d54b6f)","type":"connect"}}
```