### PR TITLE
Feature/improve signaling notify

### DIFF
--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -314,7 +314,7 @@ public final class MediaChannel {
         peerChannel.internalHandlers.onReceiveSignaling = { message in
             Logger.debug(type: .mediaChannel, message: "receive signaling")
             switch message {
-            case .notifyConnection(let message):
+            case .notify(let message):
                 self.publisherCount = message.publisherCount
                 self.subscriberCount = message.subscriberCount
             default:

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -444,8 +444,9 @@ public struct SignalingPush {
 /**
  "notify" シグナリングメッセージで通知されるイベントの種別です。
  詳細は Sora のドキュメントを参照してください。
+ 廃止されました。
  */
-/*
+@available(*, unavailable, message: "SignalingNotifyEventType は廃止されました。")
 public enum SignalingNotifyEventType {
     
     /// "connection.created"
@@ -464,10 +465,13 @@ public enum SignalingNotifyEventType {
     case networkStatus
     
 }
- */
 
-// これまでは eventType が増えた際にエラーになっていたので、 type: notify に対応する struct を1つに統合してそれを防ぐ
-// eventType 以外は全て Optional にする必要がある
+/// "notidy" シグナリングメッセージを表します。
+///
+/// type:notify の event_type ごとに struct を定義するのではなく、 type: notify に対して1つの struct を定義しています。
+/// そのため、アクセスする際は eventType をチェックする必要があります。
+///
+/// 上記の理由により、この struct では、 eventType 以外のパラメーターを Optional にする必要があります。
 public struct SignalingNotify {
 
     // SignalingNotifyConnection から引き継いだ値
@@ -555,14 +559,16 @@ public struct SignalingNotify {
  - `connection.destroyed`
  
  このメッセージは接続の確立後、チャネルへの接続数に変更があるとサーバーから送信されます。
+ 廃止されました。
+ SignalingNotify を利用してください。
  */
-/*
+@available(*, unavailable, message: "SignalingNotifyConnection は廃止されました。  SignalingNotify を利用してください。")
 public struct SignalingNotifyConnection {
 
     // MARK: イベント情報
     
     /// イベントの種別
-    public var eventType: SignalingNotifyEventType
+    public var eventType: Any
     
     // MARK: 接続情報
     
@@ -622,12 +628,13 @@ public struct SignalingNotifyConnection {
     public var channelSendrecvConnections: Int?
 
 }
-*/
 
 /**
  "notify" シグナリングメッセージのうち、 `spotlight.changed` イベントを表します。
+ 廃止されました。
+ SignalingNotify を利用してください。
  */
-/*
+@available(*, unavailable, message: "SignalingNotifySpotlightChanged は廃止されました。 SignalingNotify を利用してください。")
 public struct SignalingNotifySpotlightChanged {
     
     /// クライアント ID
@@ -649,19 +656,19 @@ public struct SignalingNotifySpotlightChanged {
     public var videoEnabled: Bool?
     
 }
-*/
 
 /**
  "notify" シグナリングメッセージのうち、 "network.status" イベントを表します。
+ 廃止されました。
+ SignalingNotify を利用してください。
  */
-/*
+@available(*, unavailable, message: "SignalingNotifyNetworkStatus は廃止されました。 SignalingNotify を利用してください。")
 public struct SignalingNotifyNetworkStatus {
     
     /// ネットワークの不安定度
     public var unstableLevel: Int
     
 }
-*/
 
 /**
  "ping" シグナリングメッセージを表します。
@@ -1110,126 +1117,6 @@ extension SignalingNotify: Codable {
     }
     
 }
-
-/// :nodoc:
-/*
-extension SignalingNotifyConnection: Codable {
-    
-    enum CodingKeys: String, CodingKey {
-        case event_type
-        case role
-        case client_id
-        case connection_id
-        case audio
-        case video
-        case minutes
-        case channel_connections
-        case channel_upstream_connections
-        case channel_downstream_connections
-        case channel_sendonly_connections
-        case channel_recvonly_connections
-        case channel_sendrecv_connections
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        eventType = try container.decode(SignalingNotifyEventType.self,
-                                         forKey: .event_type)
-        role = try container.decode(SignalingRole.self, forKey: .role)
-        clientId = try container.decodeIfPresent(String.self, forKey: .client_id)
-        connectionId = try container.decodeIfPresent(String.self,
-                                                     forKey: .connection_id)
-        audioEnabled = try container.decodeIfPresent(Bool.self, forKey: .audio)
-        videoEnabled = try container.decodeIfPresent(Bool.self, forKey: .video)
-        connectionTime = try container.decode(Int.self, forKey: .minutes)
-        connectionCount =
-            try container.decode(Int.self, forKey: .channel_connections)
-        publisherCount =
-            try container.decodeIfPresent(Int.self, forKey: .channel_upstream_connections)
-        subscriberCount =
-            try container.decodeIfPresent(Int.self, forKey: .channel_downstream_connections)
-        channelSendonlyConnections =
-               try container.decodeIfPresent(Int.self, forKey: .channel_sendonly_connections)
-        channelRecvonlyConnections =
-               try container.decodeIfPresent(Int.self, forKey: .channel_recvonly_connections)
-        channelSendrecvConnections =
-               try container.decodeIfPresent(Int.self, forKey: .channel_sendrecv_connections)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        throw SoraError.invalidSignalingMessage
-    }
-    
-}
-*/
-/*
- private var signalingNotifyEventType: PairTable<String, SignalingNotifyEventType> =
-    PairTable(name: "SignalingNotifyEventType",
-              pairs: [("connection.created", .connectionCreated),
-                      ("connection.updated", .connectionUpdated),
-                      ("connection.destroyed", .connectionDestroyed),
-                      ("spotlight.changed", .spotlightChanged),
-                      ("network.status", .networkStatus)])
-
-/// :nodoc:
-extension SignalingNotifyEventType: Codable {
-    
-    public init(from decoder: Decoder) throws {
-        self = try signalingNotifyEventType.decode(from: decoder)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        try signalingNotifyEventType.encode(self, to: encoder)
-    }
-    
-}
-
-/// :nodoc:
-extension SignalingNotifySpotlightChanged: Codable {
-    
-    enum CodingKeys: String, CodingKey {
-        case client_id
-        case connection_id
-        case spotlight_id
-        case fixed
-        case audio
-        case video
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        clientId = try container.decode(String?.self, forKey: .client_id)
-        connectionId = try container.decode(String?.self, forKey: .connection_id)
-        spotlightId = try container.decode(String.self, forKey: .spotlight_id)
-        isFixed = try container.decodeIfPresent(Bool.self, forKey: .fixed)
-        audioEnabled = try container.decodeIfPresent(Bool.self, forKey: .audio)
-        videoEnabled = try container.decodeIfPresent(Bool.self, forKey: .video)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        throw SoraError.invalidSignalingMessage
-    }
-    
-}
-
-/// :nodoc:
-extension SignalingNotifyNetworkStatus: Codable {
-    
-    enum CodingKeys: String, CodingKey {
-        case unstable_level
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        unstableLevel = try container.decode(Int.self, forKey: .unstable_level)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        throw SoraError.invalidSignalingMessage
-    }
-    
-}
-*/
 
 /// :nodoc:
 extension SignalingPing: Codable {

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -513,7 +513,7 @@ public struct SignalingNotify {
     
     // MARK: 接続状態
     
-    /// 接続時間
+    /// 接続時間 (分)
     public var connectionTime: Int?
     
     /// 接続中のクライアントの数
@@ -599,7 +599,7 @@ public struct SignalingNotifyConnection {
     
     // MARK: 接続状態
     
-    /// 接続時間
+    /// 接続時間 (分)
     public var connectionTime: Int
     
     /// 接続中のクライアントの数

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -474,8 +474,6 @@ public enum SignalingNotifyEventType {
 /// 上記の理由により、この struct では、 eventType 以外のパラメーターを Optional にする必要があります。
 public struct SignalingNotify {
 
-    // SignalingNotifyConnection から引き継いだ値
-    
     // MARK: イベント情報
     
     /// イベントの種別
@@ -538,15 +536,12 @@ public struct SignalingNotify {
     /// 接続中の送受信可能接続の数
     public var channelSendrecvConnections: Int?
     
-    // SignalingNotifySpotlightChanged から引き継いだ値
-
     /// スポットライト ID
     public var spotlightId: String?
     
     /// 固定の有無
     public var isFixed: Bool?
     
-    // SignalingNotifyNetworkStatus から引き継いだ値
     /// ネットワークの不安定度
     public var unstableLevel: Int?
 }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -1070,7 +1070,7 @@ extension SignalingNotify: Codable {
         case channel_recvonly_connections
         case channel_sendrecv_connections
         case spotlight_id
-        case is_fixed
+        case fixed
         case unstable_level
     }
     
@@ -1100,7 +1100,7 @@ extension SignalingNotify: Codable {
         spotlightId =
             try container.decodeIfPresent(String.self, forKey: .spotlight_id)
         isFixed =
-            try container.decodeIfPresent(Bool.self, forKey: .is_fixed)
+            try container.decodeIfPresent(Bool.self, forKey: .fixed)
         unstableLevel =
             try container.decodeIfPresent(Int.self, forKey: .unstable_level)
     }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -466,7 +466,7 @@ public enum SignalingNotifyEventType {
     
 }
 
-/// "notidy" シグナリングメッセージを表します。
+/// "notify" シグナリングメッセージを表します。
 ///
 /// type:notify の event_type ごとに struct を定義するのではなく、 type: notify に対して1つの struct を定義しています。
 /// そのため、アクセスする際は eventType をチェックする必要があります。


### PR DESCRIPTION
## 変更内容

- Signaling の type: notify において、  event_type の種類が増えたらエラーが発生する問題を解消します

## 実装

- これまでは event_type ごとに struct が存在しましたが、それを1つに統合した SignalingNotify を追加します
  - この struct においては、 event_type 以外の値は全て Optional にする必要があります

## 残タスク & 議論

- [x] 新しく追加された event_type への対応
  - Sora の次のリリースで "spotlight.focused", "spotlight.focused" が追加される予定だが、パラメーターの追加は不要でした
  - 参考: https://sora-doc-dev.shiguredo.jp/signaling_type
- [x] `@available` アノテーションの付与
  - unavailable 使用の可否について、別 PR で方針を議論中 => unavailable を付与する
- [x] `srtuct SignalingNotify` へ、処理前の JSON オブジェクトをパラメーターとして追加するか? 確認する => 不要
  - WebSocket でシグナリング・メッセージを受信した際に処理をすれば良いので
- [x] 動作確認
  - 修正した sora-ios-sdk-quickstart を利用して、シグナリング受信時の struct の値を確認する
  - sora-ios-sdk-quickstart https://github.com/shiguredo/sora-ios-sdk-quickstart/tree/feature/improve-signaling-notify