### PR TITLE
WebRTC を M91 に更新する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [UPDATE] サイマルキャストで VP8 / H.264 (ハードウェアアクセラレーション含む) に対応する
     - @szktty @enm10k
-- [UPDATE] WebRTC 90.4430.3.2 に上げる
+- [UPDATE] WebRTC 91.4472.9.1 に上げる
     - @enm10k
 - [ADD] libwebrtc のログレベルを設定する API を追加
     - `Sora.setWebRTCLogLevel(_:)`

--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,6 @@ platform :ios, '10.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '90.4430.3.2'
+  pod 'WebRTC', '91.4472.9.1'
   pod 'Starscream', '3.1.1'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sora iOS SDK
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-m88.4324-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/4240)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-m91.4472-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/4472)
 [![GitHub tag](https://img.shields.io/github/tag/shiguredo/sora-ios-sdk.svg)](https://github.com/shiguredo/sora-ios-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/info.json', 'Sora/*.xib']
   s.prepare_command = 'sh Sora/info.sh'
-  s.dependency "WebRTC", '90.4430.3.2'
+  s.dependency "WebRTC", '91.4472.9.1'
   s.dependency "Starscream", "3.1.1"
 end

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -124,7 +124,8 @@ class NativePeerChannelFactory {
                               handler: @escaping (String?, Error?) -> Void) {
         let peer = createNativePeerChannel(configuration: configuration, constraints: constraints, delegate: nil)
         
-        guard let peer = peer else {
+        // `guard let peer = peer {` と書いた場合、 Xcode 12.5 でビルド・エラーになった
+        guard let peer2 = peer else {
             handler(nil, SoraError.peerChannelError(reason: "createNativePeerChannel failed"))
             return
         }
@@ -133,15 +134,15 @@ class NativePeerChannelFactory {
                                                  videoTrackId: "video",
                                                  audioTrackId: "audio",
                                                  constraints: constraints)
-        peer.add(stream.videoTracks[0], streamIds: [stream.streamId])
-        peer.add(stream.audioTracks[0], streamIds: [stream.streamId])
-        peer.offer(for: constraints.nativeValue) { sdp, error in
+        peer2.add(stream.videoTracks[0], streamIds: [stream.streamId])
+        peer2.add(stream.audioTracks[0], streamIds: [stream.streamId])
+        peer2.offer(for: constraints.nativeValue) { sdp, error in
             if let error = error {
                 handler(nil, error)
             } else if let sdp = sdp {
                 handler(sdp.sdp, nil)
             }
-            peer.close()
+            peer2.close()
         }
     }
     

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -60,7 +60,7 @@ class NativePeerChannelFactory {
     
     func createNativePeerChannel(configuration: WebRTCConfiguration,
                                  constraints: MediaConstraints,
-                                 delegate: RTCPeerConnectionDelegate?) -> RTCPeerConnection {
+                                 delegate: RTCPeerConnectionDelegate?) -> RTCPeerConnection? {
         return nativeFactory
             .peerConnection(with: configuration.nativeValue,
                             constraints: constraints.nativeValue,
@@ -123,6 +123,12 @@ class NativePeerChannelFactory {
                               constraints: MediaConstraints,
                               handler: @escaping (String?, Error?) -> Void) {
         let peer = createNativePeerChannel(configuration: configuration, constraints: constraints, delegate: nil)
+        
+        guard let peer = peer else {
+            handler(nil, SoraError.peerChannelError(reason: "createNativePeerChannel failed"))
+            return
+        }
+        
         let stream = createNativeSenderStream(streamId: "offer",
                                                  videoTrackId: "video",
                                                  audioTrackId: "audio",

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -439,6 +439,9 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     
     weak var channel: BasicPeerChannel!
     var state: State = .disconnected
+    
+    // connect() の成功後は必ずセットされるので nil チェックを省略する
+    // connect() 実行前は nil なのでアクセスしないこと
     var nativeChannel: RTCPeerConnection!
     var internalState: PeerChannelInternalState!
     
@@ -499,6 +502,14 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             .createNativePeerChannel(configuration: webRTCConfiguration,
                                      constraints: webRTCConfiguration.constraints,
                                      delegate: self)
+        
+        guard nativeChannel != nil else {
+            let message = "createNativePeerChannel failed"
+            Logger.debug(type: .peerChannel, message: message)
+            handler(SoraError.peerChannelError(reason: message))
+            return
+        }
+
         internalState = PeerChannelInternalState(
             signalingState: PeerChannelSignalingState(
                 nativeValue: nativeChannel.signalingState),

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -439,7 +439,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     
     weak var channel: BasicPeerChannel!
     var state: State = .disconnected
-    var nativeChannel: RTCPeerConnection?
+    var nativeChannel: RTCPeerConnection!
     var internalState: PeerChannelInternalState!
     
     var signalingChannel: SignalingChannel {
@@ -499,11 +499,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             .createNativePeerChannel(configuration: webRTCConfiguration,
                                      constraints: webRTCConfiguration.constraints,
                                      delegate: self)
-        guard let nativeChannel = self.nativeChannel else {
-            handler(SoraError.peerChannelError(reason: "connect failed: nativeCannel is not initialized"))
-            return
-        }
-        
         internalState = PeerChannelInternalState(
             signalingState: PeerChannelSignalingState(
                 nativeValue: nativeChannel.signalingState),
@@ -620,14 +615,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         Logger.debug(type: .peerChannel,
                      message: "initialize sender stream")
         
-        guard let nativeChannel = nativeChannel else {
-            let message = "initializeSenderStream failed: nativeChannel is not initialized"
-            Logger.error(type: .peerChannel, message: message)
-            self.disconnect(error: SoraError
-                .peerChannelError(reason: message))
-            return
-        }
-        
         let nativeStream = NativePeerChannelFactory.default
             .createNativeSenderStream(streamId: configuration.publisherStreamId,
                                          videoTrackId:
@@ -721,10 +708,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                       handler: @escaping (String?, Error?) -> Void) {
         Logger.debug(type: .peerChannel, message: "try create answer")
         Logger.debug(type: .peerChannel, message: offer)
-        guard let nativeChannel = nativeChannel else {
-            handler(nil, SoraError.peerChannelError(reason: "createAnswer failed: nativeCannel is not initialized"))
-            return
-        }
         
         Logger.debug(type: .peerChannel, message: "try setting remote description")
         let offer = RTCSessionDescription(type: .offer, sdp: offer)
@@ -744,11 +727,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             }
             
             Logger.debug(type: .peerChannel, message: "try creating native answer")
-            guard let nativeChannel = self.nativeChannel else {
-                handler(nil, SoraError.peerChannelError(reason: "setRemoteDescription failed: nativeCannel is not initialized"))
-                return
-            }
-            nativeChannel.answer(for: constraints) { answer, error in
+            self.nativeChannel.answer(for: constraints) { answer, error in
                 guard error == nil else {
                     Logger.debug(type: .peerChannel,
                                  message: "failed creating native answer (\(error!.localizedDescription)")
@@ -758,7 +737,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                 Logger.debug(type: .peerChannel, message: "did create answer")
                 
                 Logger.debug(type: .peerChannel, message: "try setting local description")
-                nativeChannel.setLocalDescription(answer!) { error in
+                self.nativeChannel.setLocalDescription(answer!) { error in
                     guard error == nil else {
                         Logger.debug(type: .peerChannel,
                                      message: "failed setting local description")
@@ -782,12 +761,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             return
         }
         Logger.debug(type: .peerChannel, message: "update sender offer encodings")
-        
-        guard let nativeChannel = self.nativeChannel else {
-            Logger.error(type: .peerChannel, message: "updateSenderOfferEncodings failed: nativeCannel is not initialized")
-            return
-        }
-        
         for sender in nativeChannel.senders {
             sender.updateOfferEncodings(oldEncodings)
         }
@@ -797,14 +770,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         Logger.debug(type: .peerChannel, message: "try sending answer")
         state = .waitingComplete
         offerEncodings = offer.encodings
-        
-        guard let nativeChannel = self.nativeChannel else {
-            let message = "createAndSendAnswer failed: nativeCannel is not initialized"
-            Logger.error(type: .peerChannel, message: message)
-            self.disconnect(error: SoraError
-                .peerChannelError(reason: message))
-            return
-        }
         
         if let config = offer.configuration {
             Logger.debug(type: .peerChannel, message: "update configuration")
@@ -889,7 +854,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         case .ping(let ping):
             let pong = SignalingPong()
             if ping.statisticsEnabled == true {
-                nativeChannel?.statistics { report in
+                nativeChannel.statistics { report in
                     var json: [String: Any] = ["type": "pong"]
                     let stats = Statistics(contentsOf: report)
                     json["stats"] = stats.jsonObject
@@ -922,9 +887,9 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         Logger.debug(type: .peerChannel,
                      message: "media streams = \(channel.streams.count)")
         Logger.debug(type: .peerChannel,
-                     message: "native senders = \(String(describing: nativeChannel?.senders.count))")
+                     message: "native senders = \(nativeChannel.senders.count)")
         Logger.debug(type: .peerChannel,
-                     message: "native receivers = \(String(describing: nativeChannel?.receivers.count))")
+                     message: "native receivers = \(nativeChannel.receivers.count)")
         state = .connected
         
         if onConnectHandler != nil {
@@ -958,7 +923,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             terminateSenderStream()
         }
         channel.terminateAllStreams()
-        nativeChannel?.close()
+        nativeChannel.close()
         
         signalingChannel.send(message: Signaling.disconnect)
         signalingChannel.disconnect(error: error)


### PR DESCRIPTION
## 変更内容

- WebRTC を M91 に更新しました
  - createNativePeerChannel の返す値が Optional になった点に対応しました

## TODO

- [x] 動作確認
- [x] Podfile の更新
  - 参照する WebRTC を M91 にする
- [x] ドキュメントの更新