### PR TITLE
[DO NOT MERGE] SwiftPM 対応

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
         .target(
             name: "Sora",
-            dependencies: ["WebRTC", "CoreGraphics", "Starscream"],
             path: "Sora"),
+            dependencies: ["WebRTC", "Starscream"],
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let file = "WebRTC-91.4472.9.1/WebRTC.xcframework.zip"
+
+let package = Package(
+    name: "Sora",
+    products: [
+        .library(name: "Sora", targets: ["Sora"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/daltoniam/Starscream.git", .exact( "3.1.1")),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "WebRTC",
+            url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
+            checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
+        .target(
+            name: "Sora",
+            dependencies: ["Starscream"]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,14 @@
 // swift-tools-version:5.3
 
 import PackageDescription
+import Foundation
 
 let file = "WebRTC-91.4472.9.1/WebRTC.xcframework.zip"
+
+// info.sh を実行する
+let buildInfo = Process()
+buildInfo.arguments = ["sh", "Sora/info.sh"]
+buildInfo.waitUntilExit()
 
 let package = Package(
     name: "Sora",
@@ -21,7 +27,9 @@ let package = Package(
             checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
         .target(
             name: "Sora",
-            path: "Sora"),
             dependencies: ["WebRTC", "Starscream"],
+            path: "Sora",
+            exclude: ["Info.plist", "info.sh"],
+            resources: [.process("info.json"), .process("Sora/VideoView.xib")])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     name: "Sora",
     products: [
         .library(name: "Sora", targets: ["Sora"]),
+        .library(name: "WebRTC", targets: ["WebRTC"]),
     ],
     dependencies: [
         .package(url: "https://github.com/daltoniam/Starscream.git", .exact( "3.1.1")),
@@ -19,7 +20,7 @@ let package = Package(
             checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
         .target(
             name: "Sora",
-            dependencies: ["Starscream"],
+            dependencies: ["WebRTC", "Starscream"],
             path: "Sora"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
             checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
         .target(
             name: "Sora",
-            dependencies: ["Starscream"]),
+            dependencies: ["Starscream"],
+            path: "Sora"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WebRTC", targets: ["WebRTC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream.git", .exact( "3.1.1")),
+        .package(url: "https://github.com/daltoniam/Starscream.git", .exact( "4.0.4")),
     ],
     targets: [
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let file = "WebRTC-91.4472.9.1/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
+    platforms: [.iOS(.v10)],
     products: [
         .library(name: "Sora", targets: ["Sora"]),
         .library(name: "WebRTC", targets: ["WebRTC"]),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "a2b4649cb6475202ad773774f116038a5bf0c98483373a77851f7c2e5912d0c8"),
+            checksum: "9cd8261c3c32934e8fd589ab2c2395076ca0b84df56e0cbdcd6982012910ecfb"),
         .target(
             name: "Sora",
             dependencies: ["WebRTC", "Starscream"],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
         .target(
             name: "Sora",
-            dependencies: ["WebRTC", "Starscream"],
+            dependencies: ["WebRTC", "CoreGraphics", "Starscream"],
             path: "Sora"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let file = "WebRTC-91.4472.9.1/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(name: "Sora", targets: ["Sora"]),
         .library(name: "WebRTC", targets: ["WebRTC"]),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "1951c3e83259a28f594b0447565c6284cd6a281639492179799428e17e1da325"),
+            checksum: "a2b4649cb6475202ad773774f116038a5bf0c98483373a77851f7c2e5912d0c8"),
         .target(
             name: "Sora",
             dependencies: ["WebRTC", "Starscream"],

--- a/Sora/AspectRatio.swift
+++ b/Sora/AspectRatio.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 /// :nodoc:
 public enum AspectRatio {

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -7,10 +7,10 @@ class WrapperVideoEncoderFactory: NSObject, RTCVideoEncoderFactory {
 
     var defaultEncoderFactory: RTCDefaultVideoEncoderFactory
 
-    var simulcastEncoderFactory: RTCVideoEncoderFactorySimulcast
+   // var simulcastEncoderFactory: RTCVideoEncoderFactorySimulcast
 
     var currentEncoderFactory: RTCVideoEncoderFactory {
-        simulcastEnabled ? simulcastEncoderFactory : defaultEncoderFactory
+        defaultEncoderFactory
     }
 
     var simulcastEnabled = false
@@ -18,7 +18,7 @@ class WrapperVideoEncoderFactory: NSObject, RTCVideoEncoderFactory {
     override init() {
         // Sora iOS SDK では VP8, VP9, H.264 が有効
         defaultEncoderFactory = RTCDefaultVideoEncoderFactory()
-        simulcastEncoderFactory = RTCVideoEncoderFactorySimulcast(primary: defaultEncoderFactory, fallback: defaultEncoderFactory)
+        //simulcastEncoderFactory = RTCVideoEncoderFactorySimulcast(primary: defaultEncoderFactory, fallback: defaultEncoderFactory)
     }
 
     func createEncoder(_ info: RTCVideoCodecInfo) -> RTCVideoEncoder? {

--- a/Sora/SoraError.swift
+++ b/Sora/SoraError.swift
@@ -81,6 +81,7 @@ extension WSError: LocalizedError {
     
     public var errorDescription: String? {
         var desc = "\(code): "
+        /*
         switch type {
         case .closeError:
             desc += "close error"
@@ -98,6 +99,7 @@ extension WSError: LocalizedError {
             desc += "write timeout error"
         }
         desc += ": \(message)"
+ */
         return desc
     }
 

--- a/Sora/VideoView.swift
+++ b/Sora/VideoView.swift
@@ -43,7 +43,8 @@ public class VideoView: UIView {
     // また、遅延プロパティでもキーウィンドウ外で初期化すれば
     // エラーが発生するため、根本的な解決策ではないので注意
     private lazy var contentView: VideoViewContentView = {
-        guard let topLevel = Bundle(for: VideoView.self)
+        //guard let topLevel = Bundle(for: VideoView.self)
+        guard let topLevel = Bundle.module
             .loadNibNamed("VideoView", owner: self, options: nil) else
         {
             fatalError("cannot load VideoView's nib file")

--- a/Sora/VideoView.xib
+++ b/Sora/VideoView.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VideoView" customModule="Sora" customModuleProvider="target"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="VideoViewContentView" customModule="Sora" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="VideoViewContentView" customModule="Sora">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/Sora/WebSocketChannel.swift
+++ b/Sora/WebSocketChannel.swift
@@ -294,6 +294,10 @@ class BasicWebSocketChannel: WebSocketChannel {
 }
 
 class BasicWebSocketChannelContext: NSObject, WebSocketDelegate {
+    func didReceive(event: WebSocketEvent, client: WebSocket) {
+
+    }
+
     
     weak var channel: BasicWebSocketChannel!
     var nativeChannel: WebSocket
@@ -309,7 +313,7 @@ class BasicWebSocketChannelContext: NSObject, WebSocketDelegate {
 
     init(channel: BasicWebSocketChannel) {
         self.channel = channel
-        nativeChannel = WebSocket(url: channel.url)
+        nativeChannel = WebSocket(request: .init(url: channel.url))
         super.init()
         nativeChannel.delegate = self
     }


### PR DESCRIPTION
SwiftPM に対応するための暫定的なコードです。本ブランチを SwiftPM パッケージとして使うことができますが、ビルドのためのワークアラウンドを含むのでマージしないでください。 SwiftPM 対応の参考として残しておきます。 SwiftPM に正式に対応したら閉じます。

## 本ブランチを SwiftPM パッケージとして使う手順

- 任意のプロジェクトの *.xcodeproj を Xcode で開く
- メニューから "File > Swift Packages > Add Package Dependency..." を選択する
- Sora iOS SDK のリポジトリの URL を指定する
- feature/swiftpm ブランチを指定する

ローカルのリポジトリをプロジェクトで扱いたい場合は、ローカルのディレクトリをプロジェクトにドラッグします。

## PR の内容

- Package.swift の追加
- iOS 12 にアップデート
- Starscream のアップデートとソースコードの修正
- バンドルリソースの扱いの修正
- VideoView の設定の修正