### PR TITLE
re-offer, re-answer に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
     - @miosakuma
 - [UPDATE] Starscream のバージョンを 4.0.4 に更新する
     - @szktty @enm10k
+- [UPDATE] シグナリング・メッセージ re-offer, re-answer に対応する
+    - @enm10k
 - [CHANGE] 接続開始時のカメラ・デバイスを指定可能にする
     - `Configuration.cameraSettings.position` に `.front` または `.back` を設定して、接続開始時のカメラ・デバイスを指定します
     - この修正に伴い、以下の API が変更されました

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -474,7 +474,7 @@ public struct SignalingUpdate {
 }
 
 /**
- "re-offer"　メッセージ
+ "re-offer" メッセージ
  */
 public struct SignalingReOffer {
  

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -101,6 +101,12 @@ public enum Signaling {
     /// "update" シグナリング
     case update(SignalingUpdate)
     
+    /// "re-offer" シグナリング
+    case reOffer(SignalingReOffer)
+    
+    /// "re-answer" シグナリング
+    case reAnswer(SignalingReAnswer)
+    
     /// "candidate" シグナリング
     case candidate(SignalingCandidate)
 
@@ -142,6 +148,10 @@ public enum Signaling {
             return "answer"
         case .update(_):
             return "update"
+        case .reOffer(_):
+            return "re-offer"
+        case .reAnswer(_):
+            return "re-answer"
         case .candidate(_):
             return "candidate"
         case .notify:
@@ -464,6 +474,24 @@ public struct SignalingUpdate {
 }
 
 /**
+ "re-offer"　メッセージ
+ */
+public struct SignalingReOffer {
+ 
+    /// SDP メッセージ
+    public let sdp: String
+}
+
+/**
+ "re-answer" メッセージ
+ */
+public struct SignalingReAnswer {
+
+    /// SDP メッセージ
+    public let sdp: String
+}
+
+/**
  "push" シグナリングメッセージを表します。
  このメッセージは Sora のプッシュ API を使用して送信されたデータです。
  */
@@ -734,6 +762,7 @@ extension Signaling: Codable {
         case offer
         case answer
         case update
+        case reAnswer
         case candidate
         case notify
         case ping
@@ -764,6 +793,8 @@ extension Signaling: Codable {
             self = .ping(try SignalingPing(from: decoder))
         case "push":
             self = .push(try SignalingPush(from: decoder))
+        case "re-offer":
+            self = .reOffer(try SignalingReOffer(from: decoder))
         default:
             throw SoraError.unknownSignalingMessageType(type: type)
         }
@@ -786,6 +817,9 @@ extension Signaling: Codable {
             try message.encode(to: encoder)
         case .update(let message):
             try container.encode(MessageType.update.rawValue, forKey: .type)
+            try message.encode(to: encoder)
+        case .reAnswer(let message):
+            try container.encode(self.typeName(), forKey: .type)
             try message.encode(to: encoder)
         case .pong:
             try container.encode(MessageType.pong.rawValue, forKey: .type)
@@ -1107,6 +1141,43 @@ extension SignalingUpdate: Codable {
         try container.encode(sdp, forKey: .sdp)
     }
     
+}
+
+/// :nodoc:
+extension SignalingReOffer: Codable {
+    
+    enum CodingKeys: String, CodingKey {
+        case sdp
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sdp = try container.decode(String.self, forKey: .sdp)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sdp, forKey: .sdp)
+    }
+    
+}
+
+/// :nodoc:
+extension SignalingReAnswer: Codable {
+    
+    enum CodingKeys: String, CodingKey {
+        case sdp
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sdp = try container.decode(String.self, forKey: .sdp)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sdp, forKey: .sdp)
+    }
 }
 
 /// :nodoc:


### PR DESCRIPTION
## 変更内容

- Sora の更新に伴い、 re-offer, re-answer を利用したシグナリングに対応しました
- re-offer, re-answer については以下のドキュメントを参照してください
  - https://sora-doc.shiguredo.jp/deprecated#type:update%E3%81%AE%E5%BB%83%E6%AD%A2
  - https://sora-doc.shiguredo.jp/signaling_type

## 悩んでいる点

- 将来 update が廃止された際に、 PeerChannelHandlers.onUpdate の名称を変更するかどうか?