### PR TITLE
Feature/fix memory leak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
     - @szktty @enm10k
 - [FIX] 接続、切断の検知に RTCPeerConnectionState を参照する
     - @enm10k
+- [FIX] 接続終了後に MediaChannel のメモリが解放されずに残り続ける事象を修正する
+    - @szktty
 
 ## 2021.1
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -368,7 +368,9 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         // また、 (非レガシーな) スポットライトはサイマルキャストを利用しているため、同様に設定が必要になる
         WrapperVideoEncoderFactory.shared.simulcastEnabled = configuration.simulcastEnabled || (!Sora.isSpotlightLegacyEnabled && configuration.spotlightEnabled == .enabled)
         
-        signalingChannel.connect(handler: sendConnectMessage)
+        signalingChannel.connect { [weak self] error in
+            self?.sendConnectMessage(error: error)
+        }
         state = .connecting
     }
     

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -329,11 +329,13 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         super.init()
         lock.context = self
         
-        signalingChannel.internalHandlers.onDisconnect = { error in
-            self.disconnect(error: error)
+        signalingChannel.internalHandlers.onDisconnect = { [weak self] error in
+            self?.disconnect(error: error)
         }
         
-        signalingChannel.internalHandlers.onReceive = handle
+        signalingChannel.internalHandlers.onReceive = { [weak self] signaling in
+            self?.handle(signaling: signaling)
+        }
     }
     
     func connect(handler: @escaping (Error?) -> Void) {

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -177,11 +177,13 @@ class BasicSignalingChannel: SignalingChannel {
         self.webSocketChannel = configuration
             ._webSocketChannelType.init(url: configuration.url)
         BasicWebSocketChannel.useStarscreamCustomEngine = !configuration.allowsURLSessionWebSocketChannel
-        webSocketChannel.internalHandlers.onDisconnect = { error in
-            self.disconnect(error: error)
+        webSocketChannel.internalHandlers.onDisconnect = { [weak self] error in
+            self?.disconnect(error: error)
         }
         
-        webSocketChannel.internalHandlers.onReceive = handle
+        webSocketChannel.internalHandlers.onReceive = { [weak self] message in
+            self?.handle(message: message)
+        }
         webSocketChannel.handlers = configuration.webSocketChannelHandlers
     }
     

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -87,7 +87,7 @@ class URLSessionWebSocketChannelContext: NSObject, URLSessionDelegate, URLSessio
             
             state = .disconnecting
             webSocketTask?.cancel(with: .normalClosure, reason: nil)
-            urlSession?.finishTasksAndInvalidate()
+            urlSession?.invalidateAndCancel()
             state = .disconnected
             
             Logger.debug(type: .webSocketChannel, message: "call onDisconnect")


### PR DESCRIPTION
一度でも接続した MediaChannel がアプリケーションに破棄されてもメモリに残ってしまう事象を修正する。

## 修正内容

- 循環参照を解消する。主にクロージャー内で強参照が相互に捕捉されてしまっている箇所を弱参照に変更する
- 接続解除後に URLSession を無効 (invalidate) にする。 URLSession はデリゲートを強参照で保持しているので、明示的に無効にしないとデリゲートが解放されない

## 備考

- libwebrtc の `cricket::Codec`, `cricket::VideoCodec` のリークも確認しているが、 SDK が原因ではないと思われるので本修正には含めない