### PR TITLE
CameraVideoCapturerHandlers の init の定義が漏れており、 SDK 外から利用できなかった

### DIFF
--- a/Sora/VideoCapturer.swift
+++ b/Sora/VideoCapturer.swift
@@ -20,6 +20,7 @@ public class CameraVideoCapturerHandlers {
     // カメラの停止時に呼ばれる
     public var onStop: (() -> Void)?
     
+    public init() {}
 }
 
 /**


### PR DESCRIPTION
## 変更内容

- CameraVideoCapturer の動作確認中に見つけたバグの修正です