### PR TITLE
リソースのパスを変更する

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,6 @@ let package = Package(
             dependencies: ["WebRTC", "Starscream"],
             path: "Sora",
             exclude: ["Info.plist"],
-            resources: [.process("Sora/VideoView.xib")])
+            resources: [.process("VideoView.xib")])
     ]
 )


### PR DESCRIPTION
SwiftPM パッケージとしてプロジェクトに追加すると `Sora/VideoView.xib` が見つからない警告が出る事象を修正します。