### PR TITLE
CameraVideoCapturerHandlers をグローバルなイベントハンドラに変更する

### DIFF
--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -164,8 +164,9 @@ public final class CameraVideoCapturer {
     public private(set) var settings: Any?
     
     /// カメラの位置
-    @available(*, unavailable, message: "position は廃止されました。 現在利用されているデバイスは CameraVideoCapturer.current?.device?.position で取得してください。")
-    public var position: AVCaptureDevice.Position? = nil
+    public var position: AVCaptureDevice.Position? {
+        device?.position
+    }
 
     /// 使用中のカメラの位置に対応するデバイス
     /// captureDevice に変更されました

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -154,8 +154,9 @@ public final class CameraVideoCapturer {
     
     /// カメラが起動中であれば ``true``
     public private(set) var isRunning: Bool = false
+
     /// イベントハンドラ
-    public var handlers: CameraVideoCapturerHandlers = CameraVideoCapturerHandlers()
+    public static var handlers: CameraVideoCapturerHandlers = CameraVideoCapturerHandlers()
     
     /// カメラの設定
     /// 廃止されました
@@ -240,7 +241,7 @@ public final class CameraVideoCapturer {
             isRunning = true
             CameraVideoCapturer.current = self
             completionHandler(nil)
-            handlers.onStart?()
+            CameraVideoCapturer.handlers.onStart?(self)
         }
     }
     
@@ -266,7 +267,7 @@ public final class CameraVideoCapturer {
             isRunning = false
             CameraVideoCapturer.current = nil
             completionHandler(nil)
-            handlers.onStop?()
+            CameraVideoCapturer.handlers.onStop?(self)
         }
     }
     
@@ -453,7 +454,7 @@ private class CameraVideoCapturerDelegate: NSObject, RTCVideoCapturerDelegate {
     
     func capturer(_ capturer: RTCVideoCapturer, didCapture nativeFrame: RTCVideoFrame) {
         let frame = VideoFrame.native(capturer: capturer, frame: nativeFrame)
-        if let editedFrame = cameraVideoCapturer.handlers.onCapture?(frame) {
+        if let editedFrame = CameraVideoCapturer.handlers.onCapture?(cameraVideoCapturer, frame) {
             cameraVideoCapturer.stream?.send(videoFrame: editedFrame)
         } else {
             cameraVideoCapturer.stream?.send(videoFrame: frame)
@@ -492,16 +493,16 @@ public class CameraVideoCapturerHandlers {
     
     /// 生成された映像フレームを受け取ります。
     /// 返した映像フレームがストリームに渡されます。
-    public var onCapture: ((VideoFrame) -> VideoFrame)?
+    public var onCapture: ((CameraVideoCapturer, VideoFrame) -> VideoFrame)?
 
     /// CameraVideoCapturer.start(format:frameRate:completionHandler) 内で completionHandler の後に実行されます。
     /// そのため、 CameraVideoCapturer.restart(completionHandler) のように、 stop の completionHandler で start を実行する場合、
     /// イベントハンドラは onStart, onStop の順に呼び出されることに注意してください。
-    public var onStart: (() -> Void)?
+    public var onStart: ((CameraVideoCapturer) -> Void)?
     
     /// CameraVideoCapturer.stop(completionHandler) 内で completionHandler の後に実行されます。
     /// 注意点については、 onStart のコメントを参照してください。
-    public var onStop: (() -> Void)?
+    public var onStop: ((CameraVideoCapturer) -> Void)?
     
     /// CameraVideoCapturer のイベントハンドラを初期化します。
     public init() {}


### PR DESCRIPTION
## 概要

現在の実装では CameraVideoCapturerHandler を CameraVideoCapturer ごとにセットしているが、グローバルに一つのみセットするように変更する。ユーザーの利便性を少し上げる。

ただし、変更前の設計に問題はない。あくまでユーザーの利便性のための変更。


## 目的

CameraVideoCapturer はカメラごとに存在し、デフォルトでは前面カメラと背面カメラの 2 つのオブジェクトを生成している。ユーザーがカメラのイベントハンドラを実装する場合、両カメラの CameraVideoCapturer に実装する必要がある。大半のケースではカメラの位置に依存しない処理を実装すると思われるので、両カメラに同じコードをセットするのは二度手間になる (ただし、単純なケースではクロージャーをセットすればいいだけなので数行で済む) 。それを一度で済ませられるようにする。


## 変更内容

- CameraVideoCapturer.handlers を静的プロパティに変更する
- CameraVideoCapturerHandler の各コールバックに引数 (CameraVideoCapturer) を追加する
- CameraVideoCapturer.position の unavailable を取り止める
  - 新カメラ API では AVCaptureDevice にアクセスできるようにしたので position のラッパーを廃止したが、そのためカメラ位置の取得のコードが `CameraVideoCapturer.current?.device?.position` となり、かなり長くなる
  - 今回の変更により CameraVideoCapturerHandler 内でカメラ位置を判別することが増えると予想されるので、簡易的な API を廃止せずにしておく

## 使用例

変更前:

```swift
// 前面カメラ時
CameraVideoCapturer.front.handlers.onStart = {
    print("# front camera")
}

// 背面カメラ時
CameraVideoCapturer.back.handlers.onStart = {
    print("# back camera")
}
```

変更後:

```swift
CameraVideoCapturer.handlers.onStart = { capturer in
    // カメラ位置ごとの処理
    switch capturer.position {
    case .front:
        // 前面カメラ時
        print("# front camera")
    case .back:
        // 背面カメラ時
        print("# back camera")
    default:
        break
    }
    
    // カメラ位置に依存しない処理
    print("# capturer start => \(capturer)")
}
```

## メリット

カメラのイベントハンドラの実装が分散しない。

## デメリット

特にない。破壊的変更を含むが、カメラの新 API は未リリースなのでユーザーに影響しない。