### PR TITLE
Feature/camera video capturer device

### DIFF
--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -125,7 +125,8 @@ public final class CameraVideoCapturer {
         
         // 反対の position を持つ CameraVideoCapturer を取得する
         guard let flip: CameraVideoCapturer = (capturer.device.position == .front ? .back : .front) else {
-            completionHandler(SoraError.cameraError(reason: "device is not found"))
+            let name = capturer.device.position == .front ? "back" : "front"
+            completionHandler(SoraError.cameraError(reason: "\(name) camera is not found"))
             return
         }
         

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -30,10 +30,22 @@ public final class CameraVideoCapturer {
     }
     
     /// 前面のカメラに対応するデバイス
-    public private(set) static var front: CameraVideoCapturer = CameraVideoCapturer(device: device(for: .front) ?? nil)
+    public private(set) static var front: CameraVideoCapturer? = {
+        if let device = device(for: .front) {
+            return CameraVideoCapturer(device: device)
+        } else {
+            return nil
+        }
+    }()
 
     /// 背面のカメラに対応するデバイス
-    public private(set) static var back: CameraVideoCapturer = CameraVideoCapturer(device: device(for: .back) ?? nil)
+    public private(set) static var back: CameraVideoCapturer? = {
+        if let device = device(for: .back) {
+            return CameraVideoCapturer(device: device)
+        } else {
+            return nil
+        }
+    }()
 
     /// 起動中のデバイス
     public private(set) static var current: CameraVideoCapturer?
@@ -106,23 +118,21 @@ public final class CameraVideoCapturer {
     /// CameraVideoCapturer の起動には、 capturer と近い設定のフォーマットとフレームレートが利用されます
     /// また、起動された CameraVideoCapturer には capturer の保持する MediaStream が設定されます
     public static func flip(_ capturer: CameraVideoCapturer, completionHandler: @escaping ((Error?) -> Void)) {
-        guard capturer.device != nil else {
-            completionHandler(SoraError.cameraError(reason: "device should not be nil"))
-            return
-        }
-        
         guard capturer.format != nil else {
             completionHandler(SoraError.cameraError(reason: "format should not be nil"))
             return
         }
         
         // 反対の position を持つ CameraVideoCapturer を取得する
-        let flip: CameraVideoCapturer = capturer.device!.position == .front ? .back : .front
+        guard let flip: CameraVideoCapturer = (capturer.device.position == .front ? .back : .front) else {
+            completionHandler(SoraError.cameraError(reason: "device is not found"))
+            return
+        }
         
         let dimension = CMVideoFormatDescriptionGetDimensions(capturer.format!.formatDescription)
         guard let format = CameraVideoCapturer.format(width: dimension.width,
                                                       height: dimension.height,
-                                                      for: flip.device!) else {
+                                                      for: flip.device) else {
             completionHandler(SoraError.cameraError(reason: "CameraVideoCapturer.format failed: suitable format is not found"))
             return
         }
@@ -176,7 +186,7 @@ public final class CameraVideoCapturer {
     }
     
     /// 使用中のデバイス
-    public var device: AVCaptureDevice?
+    public var device: AVCaptureDevice
     
     /// フレームレート
     public private(set) var frameRate: Int?
@@ -194,7 +204,7 @@ public final class CameraVideoCapturer {
     /// 引数に指定した device を利用して CameraVideoCapturer を初期化します。
     /// 自動的に初期化される静的プロパティ、 front/back を定義しています。
     /// 上記以外のデバイスを利用したい場合のみ CameraVideoCapturer を生成してください。
-    public init(device: AVCaptureDevice?) {
+    public init(device: AVCaptureDevice) {
         self.device = device
         nativeDelegate = CameraVideoCapturerDelegate(cameraVideoCapturer: self)
         native = RTCCameraVideoCapturer(delegate: nativeDelegate)
@@ -217,11 +227,6 @@ public final class CameraVideoCapturer {
                       completionHandler: @escaping ((Error?) -> Void)) {
         guard isRunning == false else {
             completionHandler(SoraError.cameraError(reason: "isRunning should be false"))
-            return
-        }
-        
-        guard let device = device else {
-            completionHandler(SoraError.cameraError(reason: "device is not initialized"))
             return
         }
         

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -483,44 +483,51 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             let position = configuration.cameraSettings.position
             
             // position に対応した CameraVideoCapturer を取得する
-            guard position != .unspecified else {
+            let capturer: CameraVideoCapturer
+            switch position {
+            case .front:
+                guard let front = CameraVideoCapturer.front else {
+                    Logger.error(type: .peerChannel, message: "front camera is not found")
+                    return
+                }
+                capturer = front
+            case .back:
+                guard let back = CameraVideoCapturer.back else {
+                    Logger.error(type: .peerChannel, message: "back camera is not found")
+                    return
+                }
+                capturer = back
+            case .unspecified:
                 Logger.error(type: .peerChannel, message: "CameraSettings.position should not be .unspecified")
                 return
+            @unknown default:
+                guard let device = CameraVideoCapturer.device(for: position) else {
+                    Logger.error(type: .peerChannel, message: "device is not found for position")
+                    return
+                }
+                capturer = CameraVideoCapturer(device: device)
             }
-            let capturer = position == .front ? CameraVideoCapturer.front : CameraVideoCapturer.back
-        
-            if let device = CameraVideoCapturer.device(for: position) {
-                // デバイスに対応したフォーマットとフレームレートを取得する
-                guard let format = CameraVideoCapturer.format(width: configuration.cameraSettings.resolution.width,
-                                                              height: configuration.cameraSettings.resolution.height,
-                                                              for: device) else {
-                    Logger.error(type: .peerChannel, message: "CameraVideoCapturer.suitableFormat failed: suitable format rate is not found")
-                    return
-                }
-                
-                guard let frameRate = CameraVideoCapturer.maxFrameRate(configuration.cameraSettings.frameRate, for: format) else {
-                    Logger.error(type: .peerChannel, message: "CameraVideoCapturer.suitableFormat failed: suitable frame rate is not found")
-                    return
-                }
-                
-                if CameraVideoCapturer.current != nil && CameraVideoCapturer.current!.isRunning {
-                    // CameraVideoCapturer.current を停止してから capturer を start する
-                    CameraVideoCapturer.current!.stop() { (error: Error?) in
-                        guard error == nil else {
-                            Logger.debug(type: .peerChannel,
-                                         message: "CameraVideoCapturer.stop failed =>  \(error!)")
-                            return
-                        }
 
-                        capturer.start(format: format,
-                              frameRate: frameRate) { (error: Error?) in
-                            guard error == nil else {
-                                Logger.debug(type: .peerChannel,
-                                             message: "CameraVideoCapturer.start failed =>  \(error!)")
-                                return
-                            }
-                            capturer.stream = stream
-                        }
+            // デバイスに対応したフォーマットとフレームレートを取得する
+            guard let format = CameraVideoCapturer.format(width: configuration.cameraSettings.resolution.width,
+                                                          height: configuration.cameraSettings.resolution.height,
+                                                          for: capturer.device) else {
+                Logger.error(type: .peerChannel, message: "CameraVideoCapturer.suitableFormat failed: suitable format rate is not found")
+                return
+            }
+
+            guard let frameRate = CameraVideoCapturer.maxFrameRate(configuration.cameraSettings.frameRate, for: format) else {
+                Logger.error(type: .peerChannel, message: "CameraVideoCapturer.suitableFormat failed: suitable frame rate is not found")
+                return
+            }
+
+            if CameraVideoCapturer.current != nil && CameraVideoCapturer.current!.isRunning {
+                // CameraVideoCapturer.current を停止してから capturer を start する
+                CameraVideoCapturer.current!.stop() { (error: Error?) in
+                    guard error == nil else {
+                        Logger.debug(type: .peerChannel,
+                                     message: "CameraVideoCapturer.stop failed =>  \(error!)")
+                        return
                     }
                 } else {
                     capturer.start(format: format, frameRate: frameRate) { error in
@@ -535,10 +542,16 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                     }
                 }
             } else {
-                // 起動可能なデバイスが存在しない場合
-                // iPhone/iPad であればここに来ない
-                Logger.debug(type: .peerChannel,
-                             message: "video capturer is not found")
+                capturer.start(format: format, frameRate: frameRate) { error in
+                    guard error == nil else {
+                        Logger.debug(type: .peerChannel,
+                                     message: "CameraVideoCapturer.start failed =>  \(error!)")
+                        return
+                    }
+                    Logger.debug(type: .peerChannel,
+                                 message: "set CameraVideoCapturer to sender stream")
+                    capturer.stream = stream
+                }
             }
         }
         

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -529,7 +529,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                                      message: "CameraVideoCapturer.stop failed =>  \(error!)")
                         return
                     }
-                } else {
+
                     capturer.start(format: format, frameRate: frameRate) { error in
                         guard error == nil else {
                             Logger.debug(type: .peerChannel,


### PR DESCRIPTION
## 概要

CameraVideoCapturer.device プロパティの型を AVCaptureDevice? から AVCaptureDevice に変更する。

破壊的変更だが、新カメラ API は未リリースなのでユーザーに影響しない。

## 目的

- CameraVideoCapturer の目的は RTCCameraVideoCapturer を用いた AVCaptureDevice の操作であり、起動と停止の状態を管理しているので AVCaptureDevice と 1 対 1 で密結合する。そのため device プロパティは必ず値を持つべきで、型が Optional である必要はない。 device プロパティが nil である CameraVideoCapturer には意味がない

- front, back 静的プロパティは Optional にすべき。カメラ位置に対応する AVCaptureDevice が存在しない場合 CameraVideoCapturer.device(for:) は nil を返すが、その場合は front, back を nil にすべき。 device プロパティは必ず値を持つべきなので、 AVCaptureDevice が存在しなければ CameraVideoCapturer を生成すべきではない


## 変更内容

- CameraVideoCapturer.device の型を AVCaptureDevice に変更する
- CameraVideoCapturer.front と .back の型を CameraVideoCapturer? に変更する

