### PR TITLE
Feature/data channel signaling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [ADD] DataChannel シグナリングに対応する
+    - `Configuration.dataChannelSignaling` を追加
+    - `Configuration.ignoreDisconnectWebSocket` を追加
+    - @szktty @enm10k
+
 ## 2021.2.1
 
 - [FIX] Swift Package Manager に対応するためバージョニングを修正

--- a/Sora.xcodeproj/project.pbxproj
+++ b/Sora.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		91CDC1ED23166A5300C3A31E /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CDC1EC23166A5200C3A31E /* DeviceInfo.swift */; };
 		91FA6F211D93CA9800D38DB4 /* VideoFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA6F201D93CA9800D38DB4 /* VideoFrame.swift */; };
 		91FD95751DCA06F700047BA9 /* RTC+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD95741DCA06F700047BA9 /* RTC+Description.swift */; };
+		AD7227122716B5F100001A23 /* DataChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7227112716B5F100001A23 /* DataChannel.swift */; };
 		C5D3C7421F7CEB18004660F5 /* VideoCapturerDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D3C7411F7CEB18004660F5 /* VideoCapturerDevice.swift */; };
 /* End PBXBuildFile section */
 
@@ -118,6 +119,7 @@
 		91CDC1EC23166A5200C3A31E /* DeviceInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		91FA6F201D93CA9800D38DB4 /* VideoFrame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoFrame.swift; sourceTree = "<group>"; };
 		91FD95741DCA06F700047BA9 /* RTC+Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RTC+Description.swift"; sourceTree = "<group>"; };
+		AD7227112716B5F100001A23 /* DataChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataChannel.swift; sourceTree = "<group>"; };
 		C5D3C7411F7CEB18004660F5 /* VideoCapturerDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCapturerDevice.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -188,6 +190,7 @@
 				9173595D1F2CCEBF00806F8B /* Configuration.swift */,
 				91756E201F90A87500B70C53 /* ConnectionState.swift */,
 				9141AB631F4204C0007C4D1C /* ConnectionTimer.swift */,
+				AD7227112716B5F100001A23 /* DataChannel.swift */,
 				91CDC1EC23166A5200C3A31E /* DeviceInfo.swift */,
 				916BBF711F19EF5800846166 /* ICECandidate.swift */,
 				918A38F71F30F49500D047BA /* ICEServerInfo.swift */,
@@ -367,6 +370,7 @@
 				9161AECA2410D75A00BA3E0E /* URLSessionWebSocketChannel.swift in Sources */,
 				9177FF9C1F2E2D1600B4FA1A /* VideoCapturer.swift in Sources */,
 				913C895A226EFC61001B2569 /* Signaling.swift in Sources */,
+				AD7227122716B5F100001A23 /* DataChannel.swift in Sources */,
 				91FD95751DCA06F700047BA9 /* RTC+Description.swift in Sources */,
 				91CD2A4A1F288A6A00D039D1 /* Sora.swift in Sources */,
 				9106C27E1F31A3470019E3C7 /* Logger.swift in Sources */,

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -152,6 +152,9 @@ public struct Configuration {
     /// `connect` シグナリングに含める通知用のメタデータ
     public var signalingConnectNotifyMetadata: Encodable?
     
+    public var dataChannelSignaling: Bool?
+    public var ignoreDisconnectWebsocket: Bool?
+    
     // MARK: - イベントハンドラ
     
     /// WebSocket チャネルに関するイベントハンドラ

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -169,9 +169,6 @@ public struct Configuration {
     /// メディアチャネルに関するイベントハンドラ
     public var mediaChannelHandlers: MediaChannelHandlers = MediaChannelHandlers()
 
-    /// データチャンネルに関するイベントハンドラ
-    ///  TODO: peerChannleHandlers, mediaChannelHandlers に移動する
-    // public var dataChannelHandlers: [String: DataChannelHandlers] = [:]
     // MARK: - 接続チャネルに関する設定
     
     /**

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -169,6 +169,8 @@ public struct Configuration {
     /// メディアチャネルに関するイベントハンドラ
     public var mediaChannelHandlers: MediaChannelHandlers = MediaChannelHandlers()
 
+    /// データチャンネルに関するイベントハンドラ
+    public var dataChannelHandlers: [String: DataChannelHandlers] = [:]
     // MARK: - 接続チャネルに関する設定
     
     /**

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -151,8 +151,13 @@ public struct Configuration {
     
     /// `connect` シグナリングに含める通知用のメタデータ
     public var signalingConnectNotifyMetadata: Encodable?
-    
+
+    /// シグナリングにおける DataChannel の利用可否。
+    /// `true` の場合、接続確立後のシグナリングを DataChannel 経由で行います。
     public var dataChannelSignaling: Bool?
+
+    /// DataChannel 経由のシグナリングを利用している際に、 WebSocket が切断されても Sora との接続を継続するためのフラグ。
+    /// 詳細: https://sora-doc.shiguredo.jp/DATA_CHANNEL_SIGNALING#07c227
     public var ignoreDisconnectWebSocket: Bool?
     
     // MARK: - イベントハンドラ

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -153,7 +153,7 @@ public struct Configuration {
     public var signalingConnectNotifyMetadata: Encodable?
     
     public var dataChannelSignaling: Bool?
-    public var ignoreDisconnectWebsocket: Bool?
+    public var ignoreDisconnectWebSocket: Bool?
     
     // MARK: - イベントハンドラ
     

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -170,7 +170,8 @@ public struct Configuration {
     public var mediaChannelHandlers: MediaChannelHandlers = MediaChannelHandlers()
 
     /// データチャンネルに関するイベントハンドラ
-    public var dataChannelHandlers: [String: DataChannelHandlers] = [:]
+    ///  TODO: peerChannleHandlers, mediaChannelHandlers に移動する
+    // public var dataChannelHandlers: [String: DataChannelHandlers] = [:]
     // MARK: - 接続チャネルに関する設定
     
     /**

--- a/Sora/ConnectionState.swift
+++ b/Sora/ConnectionState.swift
@@ -35,7 +35,7 @@ public enum ConnectionState {
         }
     }
     
-    internal init(_ state: PeerChannelConnectionState) {
+    init(_ state: PeerChannelConnectionState) {
         switch state {
         case .new:
             self = .disconnected
@@ -63,7 +63,7 @@ public enum PeerChannelConnectionState {
     case closed
     case unknown
     
-    internal init(_ state: RTCPeerConnectionState) {
+    init(_ state: RTCPeerConnectionState) {
         switch state {
         case .new:
             self = .new

--- a/Sora/ConnectionState.swift
+++ b/Sora/ConnectionState.swift
@@ -16,7 +16,6 @@ public enum SoraConnectionState {
     case unknown
     
     internal init(_ state: RTCPeerConnectionState) {
-        // 参照: https://www.w3.org/TR/webrtc/#dom-rtcicetransportstate
         switch state {
         case .new:
             self = .new

--- a/Sora/ConnectionState.swift
+++ b/Sora/ConnectionState.swift
@@ -1,7 +1,45 @@
 import Foundation
+import WebRTC
+
+/**
+ PeerChannel, MediaChannel の接続状態を表します。
+ TODO: enum 名が適切か検討する
+ */
+public enum SoraConnectionState {
+    
+    case new
+    case connecting
+    case connected
+    case disconnected
+    case failed
+    case closed
+    case unknown
+    
+    internal init(_ state: RTCPeerConnectionState) {
+        // 参照: https://www.w3.org/TR/webrtc/#dom-rtcicetransportstate
+        switch state {
+        case .new:
+            self = .new
+        case .connecting:
+            self = .connecting
+        case .connected:
+            self = .connected
+        case .disconnected:
+            self = .disconnected
+        case .failed:
+            self = .failed
+        case .closed:
+            self = .closed
+        @unknown default:
+            self = .unknown
+            break
+        }
+    }
+}
 
 /**
  接続状態を表します。
+ WebRTC の ConnectionState とは異なります。
  */
 public enum ConnectionState {
     
@@ -31,6 +69,20 @@ public enum ConnectionState {
             default:
                 return false
             }
+        }
+    }
+    
+    internal init(_ state: SoraConnectionState) {
+        switch state {
+        case .new:
+            self = .connecting
+        case .connecting:
+            self = .connecting
+        // TODO: 要議論
+        case .connected, .disconnected:
+            self = .connected
+        case .closed, .failed, .unknown:
+            self = .disconnected
         }
     }
 }

--- a/Sora/ConnectionState.swift
+++ b/Sora/ConnectionState.swift
@@ -77,7 +77,7 @@ public enum ConnectionState {
             self = .connecting
         case .connecting:
             self = .connecting
-        // TODO: 要議論
+        // RTCPeerConnectionState の disconnected は connected に遷移する可能性があるため接続中として扱う
         case .connected, .disconnected:
             self = .connected
         case .closed, .failed, .unknown:

--- a/Sora/ConnectionState.swift
+++ b/Sora/ConnectionState.swift
@@ -2,43 +2,7 @@ import Foundation
 import WebRTC
 
 /**
- PeerChannel, MediaChannel の接続状態を表します。
- TODO: enum 名が適切か検討する
- */
-public enum SoraConnectionState {
-    
-    case new
-    case connecting
-    case connected
-    case disconnected
-    case failed
-    case closed
-    case unknown
-    
-    internal init(_ state: RTCPeerConnectionState) {
-        switch state {
-        case .new:
-            self = .new
-        case .connecting:
-            self = .connecting
-        case .connected:
-            self = .connected
-        case .disconnected:
-            self = .disconnected
-        case .failed:
-            self = .failed
-        case .closed:
-            self = .closed
-        @unknown default:
-            self = .unknown
-            break
-        }
-    }
-}
-
-/**
- 接続状態を表します。
- WebRTC の ConnectionState とは異なります。
+ MediaChannel, SignalingChannel, WebSocketChannel の接続状態を表します。
  */
 public enum ConnectionState {
     
@@ -71,10 +35,10 @@ public enum ConnectionState {
         }
     }
     
-    internal init(_ state: SoraConnectionState) {
+    internal init(_ state: PeerChannelConnectionState) {
         switch state {
         case .new:
-            self = .connecting
+            self = .disconnected
         case .connecting:
             self = .connecting
         // RTCPeerConnectionState の disconnected は connected に遷移する可能性があるため接続中として扱う
@@ -82,6 +46,40 @@ public enum ConnectionState {
             self = .connected
         case .closed, .failed, .unknown:
             self = .disconnected
+        }
+    }
+}
+
+/**
+ PeerChannel の接続状態を表します。
+ */
+public enum PeerChannelConnectionState {
+    
+    case new
+    case connecting
+    case connected
+    case disconnected
+    case failed
+    case closed
+    case unknown
+    
+    internal init(_ state: RTCPeerConnectionState) {
+        switch state {
+        case .new:
+            self = .new
+        case .connecting:
+            self = .connecting
+        case .connected:
+            self = .connected
+        case .disconnected:
+            self = .disconnected
+        case .failed:
+            self = .failed
+        case .closed:
+            self = .closed
+        @unknown default:
+            self = .unknown
+            break
         }
     }
 }

--- a/Sora/ConnectionTimer.swift
+++ b/Sora/ConnectionTimer.swift
@@ -14,7 +14,7 @@ enum ConnectionMonitor {
             case .signalingChannel(let chan):
                 return chan.state
             case .peerChannel(let chan):
-                return chan.state
+                return ConnectionState(chan.state)
             }
         }
     }

--- a/Sora/ConnectionTimer.swift
+++ b/Sora/ConnectionTimer.swift
@@ -25,9 +25,11 @@ enum ConnectionMonitor {
         case .webSocketChannel(let chan):
             chan.disconnect(error: error)
         case .signalingChannel(let chan):
-            chan.disconnect(error: error)
+            // タイムアウトはシグナリングのエラーと考える
+            chan.disconnect(error: error, reason: .signalingFailure)
         case .peerChannel(let chan):
-            chan.disconnect(error: error)
+            // タイムアウトはシグナリングのエラーと考える
+            chan.disconnect(error: error, reason: .signalingFailure)
         }
     }
     

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -11,7 +11,11 @@ fileprivate class ZLibUtil {
             return nil
         }
         
-        let bufferSize = 262_144 // TODO: 毎回確保するには大きいので、 stream を利用する API に書き換える?
+        // TODO: 毎回確保するには大きいので、 stream を利用して圧縮する API への置き換えを検討する
+        // 2021年10月時点では、 DataChannel の最大メッセージサイズは 262,144 バイトだが、これを拡張する RFC が提案されている
+        // https://sora-doc.shiguredo.jp/DATA_CHANNEL_SIGNALING#48cff8
+        // https://www.rfc-editor.org/rfc/rfc8260.html
+        let bufferSize = 262_144
         let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         
         var sourceBuffer = [UInt8](input)
@@ -44,7 +48,8 @@ fileprivate class ZLibUtil {
             return nil
         }
         
-        let bufferSize = 262_144 // TODO: 毎回確保するには大きいので、 stream を利用する API に書き換える?
+        // TODO: zip と同様に、 stream を利用して解凍する API への置き換えを検討する
+        let bufferSize = 262_144
         let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         
         var sourceBuffer = [UInt8](input)

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -3,7 +3,11 @@ import Foundation
 import WebRTC
 import zlib
 
+// Apple が提供する圧縮を扱う API は zlib のヘッダーとチェックサムをサポートしていないため、当該処理を実装する必要があった
 // https://developer.apple.com/documentation/accelerate/compressing_and_decompressing_data_with_buffer_compression
+//
+// TODO: iOS 12 のサポートが不要になれば、 Compression Framework の関数を、 NSData の compressed(using), decompressed(using:) に書き換えることができる
+// それに伴い、処理に必要なバッファーのサイズを指定する必要もなくなる
 fileprivate class ZLibUtil {
     
     static func zip(_ input: Data) -> Data? {
@@ -11,7 +15,7 @@ fileprivate class ZLibUtil {
             return nil
         }
         
-        // TODO: 毎回確保するには大きいので、 stream を利用して圧縮する API への置き換えを検討する
+        // TODO: 毎回確保するには大きいので、 stream を利用して圧縮する API、もしくは NSData の compressed(using:) を使用することを検討する
         // 2021年10月時点では、 DataChannel の最大メッセージサイズは 262,144 バイトだが、これを拡張する RFC が提案されている
         // https://sora-doc.shiguredo.jp/DATA_CHANNEL_SIGNALING#48cff8
         // https://www.rfc-editor.org/rfc/rfc8260.html
@@ -48,7 +52,7 @@ fileprivate class ZLibUtil {
             return nil
         }
         
-        // TODO: zip と同様に、 stream を利用して解凍する API への置き換えを検討する
+        // TODO: zip と同様に、stream を利用して解凍する API、もしくは NSData の decompressed(using:) を使用することを検討する
         let bufferSize = 262_144
         let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -6,7 +6,7 @@ import zlib
 // https://developer.apple.com/documentation/accelerate/compressing_and_decompressing_data_with_buffer_compression
 fileprivate class ZLibUtil {
     
-    public static func zip(_ input: Data) -> Data? {
+    static func zip(_ input: Data) -> Data? {
         if input.isEmpty {
             return nil
         }
@@ -43,7 +43,7 @@ fileprivate class ZLibUtil {
         return zipped
     }
     
-    public static func unzip(_ input: Data) -> Data? {
+    static func unzip(_ input: Data) -> Data? {
         if (input.isEmpty) {
             return nil
         }
@@ -187,8 +187,8 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
 
 class DataChannel {
     
-    private let native: RTCDataChannel
-    private let delegate: BasicDataChannelDelegate
+    let native: RTCDataChannel
+    let delegate: BasicDataChannelDelegate
     
     init(dataChannel: RTCDataChannel, compress: Bool, mediaChannel: MediaChannel?, peerChannel: BasicPeerChannel?) {
         Logger.info(type: .dataChannel, message: "initialize DataChannel: label => \(dataChannel.label), compress => \(compress)")

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -1,0 +1,9 @@
+//
+//  DataChannel.swift
+//  Sora
+//
+//  Created by enm10k on 2021/10/13.
+//  Copyright © 2021 Shiguredo Inc. All rights reserved.
+//
+
+import Foundation

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -91,7 +91,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     }
     
     func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
-        Logger.debug(type: .dataChannel, message: "dataChannelDidChangeState: label => \(dataChannel.label), state => \(dataChannel.readyState.rawValue)")
+        Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState.rawValue)")
         
         if dataChannel.readyState == RTCDataChannelState.closed {
             if let handler = peerChannel?.handlers.onCloseDataChannel {
@@ -105,7 +105,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     }
     
     func dataChannel(_ dataChannel: RTCDataChannel, didChangeBufferedAmount amount: UInt64) {
-        Logger.debug(type: .dataChannel, message: "didChangeBufferedAmount: label => \(dataChannel.label), amount => \(amount)")
+        Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), amount => \(amount)")
 
         if let handler = peerChannel?.handlers.onDataChannelBufferedAmount {
             handler(dataChannel.label, amount)
@@ -117,7 +117,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     }
     
     func dataChannel(_ dataChannel: RTCDataChannel, didReceiveMessageWith buffer: RTCDataBuffer) {
-        Logger.debug(type: .dataChannel, message: "didReceiveMessageWith: label => \(dataChannel.label)")
+        Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label)")
         
         guard let peerChannel = peerChannel else {
             Logger.error(type: .dataChannel, message: "peerChannel is unavailable")

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -199,7 +199,7 @@ internal class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
                 let reOffer = try JSONDecoder().decode(SignalingReOffer.self, from: data)
                 peerChannel.context.createAndSendReAnswerOnDataChannel(forReOffer: reOffer.sdp)
             } catch {
-                Logger.error(type: .dataChannel, message: "failed to decode data to SignalingReOffer")
+                Logger.error(type: .dataChannel, message: "failed to decode SignalingReOffer")
             }
         case "e2ee":
             Logger.error(type: .dataChannel, message: "NOT IMPLEMENTED: label => \(dataChannel.label)")

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -78,7 +78,7 @@ fileprivate class ZLibUtil {
     }
 }
 
-internal class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
+class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     
     let compress: Bool
     weak var peerChannel: BasicPeerChannel?
@@ -180,7 +180,7 @@ internal class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     }
 }
 
-internal class DataChannel {
+class DataChannel {
     
     private let native: RTCDataChannel
     private let delegate: BasicDataChannelDelegate

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -204,7 +204,7 @@ class DataChannel {
     var compress: Bool {
         return delegate.compress
     }
-        
+
     func send(_ data: Data) {
         Logger.debug(type: .dataChannel, message: "\(String(describing:type(of: self))):\(#function): label => \(label), data => \(data.base64EncodedString())")
 
@@ -212,6 +212,6 @@ class DataChannel {
             Logger.error(type: .dataChannel, message: "failed to compress message")
             return
         }
-        native.sendData(RTCDataBuffer(data: data, isBinary: false)) // TODO: 返り値の確認
+        native.sendData(RTCDataBuffer(data: data, isBinary: false))
     }
 }

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -192,7 +192,7 @@ internal class DataChannel {
         native.delegate = self.delegate
     }
     
-    var lable: String {
+    var label: String {
         return native.label
     }
     
@@ -201,11 +201,12 @@ internal class DataChannel {
     }
         
     func send(_ data: Data) {
+        Logger.debug(type: .dataChannel, message: "\(String(describing:type(of: self))):\(#function): label => \(label), data => \(data.base64EncodedString())")
+
         guard let data = compress ? ZLibUtil.zip(data) : data else {
             Logger.error(type: .dataChannel, message: "failed to compress message")
             return
         }
-        
         native.sendData(RTCDataBuffer(data: data, isBinary: false)) // TODO: 返り値の確認
     }
 }

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -220,7 +220,8 @@ internal class BasicDataChannel: DataChannel {
     private let native: RTCDataChannel
     private let delegate: BasicDataChannelDelegate
     
-    init(dataChannel: RTCDataChannel, compress: Bool=true, handlers: DataChannelHandlers?, peerChannel: BasicPeerChannel) {
+    init(dataChannel: RTCDataChannel, compress: Bool, handlers: DataChannelHandlers?, peerChannel: BasicPeerChannel) {
+        Logger.info(type: .dataChannel, message: "initialize DataChannel: label => \(dataChannel.label), compress => \(compress)")
         native = dataChannel
         self.delegate = BasicDataChannelDelegate(compress: compress, handlers: handlers, peerChannel: peerChannel)
         native.delegate = self.delegate

--- a/Sora/Logger.swift
+++ b/Sora/Logger.swift
@@ -16,6 +16,7 @@ public enum LogType {
     case videoView
     case user(String)
     case configurationViewController
+    case dataChannel
 }
 
 /// :nodoc:
@@ -51,6 +52,8 @@ extension LogType: CustomStringConvertible {
             return name
         case .configurationViewController:
             return "ConfigurationViewController"
+        case .dataChannel:
+            return "DataChannel"
         }
     }
     
@@ -253,7 +256,8 @@ public final class Logger {
                      .peerChannel,
                      .nativePeerChannel,
                      .mediaChannel,
-                     .mediaStream:
+                     .mediaStream,
+                     .dataChannel:
                     out = true
                 default:
                     break

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -179,7 +179,13 @@ public final class MediaChannel {
     public let signalingChannel: SignalingChannel
     
     /// ピアチャネル
-    public let peerChannel: PeerChannel
+    public var peerChannel: PeerChannel {
+        get {
+            _peerChannel!
+        }
+    }
+    // PeerChannel に mediaChannel を保持させる際にこの書き方が必要になった
+    private var _peerChannel: PeerChannel?
     
     /// ストリームのリスト
     public var streams: [MediaStream] {
@@ -210,8 +216,15 @@ public final class MediaChannel {
             stream.streamId != configuration.publisherStreamId
         }
     }
-    
-    private var connectionTimer: ConnectionTimer
+
+    private var connectionTimer: ConnectionTimer {
+        get {
+            _connectionTimer!
+        }
+    }
+    // PeerChannel に mediaChannel を保持させる際にこの書き方が必要になった
+    private var _connectionTimer: ConnectionTimer?
+
     private let manager: Sora
     
     // MARK: - インスタンスの生成
@@ -235,21 +248,19 @@ public final class MediaChannel {
         signalingChannel.handlers =
             configuration.signalingChannelHandlers
 
-        peerChannel = configuration._peerChannelType
+        _peerChannel = configuration._peerChannelType
             .init(configuration: configuration,
-                  signalingChannel: signalingChannel)
-        peerChannel.handlers =
+                  signalingChannel: signalingChannel,
+                  mediaChannel: self)
+        _peerChannel!.handlers =
             configuration.peerChannelHandlers
         handlers = configuration.mediaChannelHandlers
         
-        connectionTimer = ConnectionTimer(monitors: [
+        _connectionTimer = ConnectionTimer(monitors: [
             .webSocketChannel(signalingChannel.webSocketChannel),
             .signalingChannel(signalingChannel),
-            .peerChannel(peerChannel)],
+            .peerChannel(_peerChannel!)],
                                           timeout: configuration.connectionTimeout)
-
-        // この位置でないとエラーになる
-        peerChannel.mediaChannel = self
     }
     
     // MARK: - 接続

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -378,7 +378,7 @@ public final class MediaChannel {
             
             if let error = error {
                 Logger.error(type: .mediaChannel, message: "failed to connect")
-                weakSelf.disconnect(error: error)
+                weakSelf.internalDisconnect(error: error, reason: .signalingFailure)
                 handler(error)
                 
                 Logger.debug(type: .mediaChannel, message: "call onConnect")
@@ -406,7 +406,7 @@ public final class MediaChannel {
      - parameter error: 接続解除の原因となったエラー
      */
     public func disconnect(error: Error?) {
-        // TODO: disconnect は SDK 内部では利用されるべきではない
+        // reason に .user を指定しているので、 disconnect は SDK 内部では利用しない
         internalDisconnect(error: error, reason: .user)
     }
     

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -129,8 +129,8 @@ public final class MediaChannel {
     }
     
     /// 接続状態
-    public var state: SoraConnectionState {
-        return peerChannel.state
+    public var state: ConnectionState {
+        return ConnectionState(peerChannel.state)
     }
     
     /// 接続中 (`state == .connected`) であれば ``true``
@@ -328,7 +328,6 @@ public final class MediaChannel {
                 return
             }
             if weakSelf.state == .connecting || weakSelf.state == .connected {
-                // PeerChannel の disconnect から MediaChannel の disconnect を呼ぶと、その中からさらに PeerChannel の disconnect を読んでいるのが気になる
                 weakSelf.internalDisconnect(error: error, reason: reason)
             }
             connectionTask.complete()
@@ -416,7 +415,7 @@ public final class MediaChannel {
     
     private func internalDisconnect(error: Error?, reason: DisconnectReason) {
         switch state {
-        case .closed:
+        case .disconnecting, .disconnected:
             break
             
         default:

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -234,6 +234,7 @@ public final class MediaChannel {
             .init(configuration: configuration)
         signalingChannel.handlers =
             configuration.signalingChannelHandlers
+
         peerChannel = configuration._peerChannelType
             .init(configuration: configuration,
                   signalingChannel: signalingChannel)
@@ -246,6 +247,9 @@ public final class MediaChannel {
             .signalingChannel(signalingChannel),
             .peerChannel(peerChannel)],
                                           timeout: configuration.connectionTimeout)
+
+        // この位置でないとエラーになる
+        peerChannel.mediaChannel = self
     }
     
     // MARK: - 接続

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -57,6 +57,14 @@ public final class MediaChannelHandlers {
     
     /// シグナリング受信時に呼ばれるクロージャー
     public var onReceiveSignaling: ((Signaling) -> Void)?
+
+    public var onOpenDataChannel: ((MediaChannel, String) -> Void)?
+    
+    public var onDataChannelMessage: ((MediaChannel, String, Data) -> Void)?
+    
+    public var onCloseDataChannel: ((MediaChannel, String) -> Void)?
+    
+    public var onDataChannelBufferedAmount: ((MediaChannel, String, UInt64) -> Void)?
     
     /// 初期化します。
     public init() {}

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -58,12 +58,16 @@ public final class MediaChannelHandlers {
     /// シグナリング受信時に呼ばれるクロージャー
     public var onReceiveSignaling: ((Signaling) -> Void)?
 
+    /// DataChannel の open 時に呼ばれるクロージャー
     public var onOpenDataChannel: ((MediaChannel, String) -> Void)?
-    
+
+    /// DataChannel のメッセージ受信時に呼ばれるクロージャー
     public var onDataChannelMessage: ((MediaChannel, String, Data) -> Void)?
-    
+
+    /// DataChannel の close 時に呼ばれるクロージャー
     public var onCloseDataChannel: ((MediaChannel, String) -> Void)?
-    
+
+    /// DataChannel の bufferedAmount 変更時に呼ばれるクロージャー
     public var onDataChannelBufferedAmount: ((MediaChannel, String, UInt64) -> Void)?
     
     /// 初期化します。

--- a/Sora/MediaStream.swift
+++ b/Sora/MediaStream.swift
@@ -52,7 +52,7 @@ public final class MediaStreamHandlers {
  メディアストリームは映像と音声の送受信を行います。
  メディアストリーム 1 つにつき、 1 つの映像と 1 つの音声を送受信可能です。
  */
-public protocol MediaStream: class {
+public protocol MediaStream: AnyObject {
     
     // MARK: - イベントハンドラ
     

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -138,6 +138,8 @@ public protocol PeerChannel: AnyObject {
     /// データチャンネル
     var dataChannels: [String: DataChannel] { get }
     
+    var switchedToDataChannel: Bool  { get }
+    
     // MARK: - インスタンスの生成
     
     /**
@@ -194,6 +196,7 @@ class BasicPeerChannel: PeerChannel {
     }
     
     var dataChannels: [String: DataChannel] = [:]
+    var switchedToDataChannel: Bool = false
     
     var context: BasicPeerChannelContext!
     
@@ -471,7 +474,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             webRTCVersion: webRTCVersion,
             environment: DeviceInfo.current.description,
             dataChannelSignaling: configuration.dataChannelSignaling,
-            ignoreDisconectWebSocket: configuration.ignoreDisconnectWebsocket)
+            ignoreDisconectWebSocket: configuration.ignoreDisconnectWebSocket)
         
         Logger.debug(type: .peerChannel, message: "send connect")
         signalingChannel.send(message: Signaling.connect(connect))
@@ -867,6 +870,12 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                 }
             } else {
                 signalingChannel.send(message: .pong(pong))
+            }
+        case .switched(let switched):
+            channel.switchedToDataChannel = true
+            signalingChannel.ignoreDisconnectWebSocket = true
+            if (signalingChannel.ignoreDisconnectWebSocket) {
+                signalingChannel.webSocketChannel.disconnect(error: nil)
             }
         default:
             break

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -208,7 +208,7 @@ public protocol PeerChannel: AnyObject {
      
      - parameter error: 接続解除の原因となったエラー
      */
-    // TODO: DisconnectReason は外部に見せたくないが ... PeerChannel を実装する上では必須になってしまった気がする
+    // TODO: DisconnectReason は外部に見せたくないが、 protocol PeerChannel の実装には必須になってしまった
     func disconnect(error: Error?, reason: DisconnectReason)
 }
 
@@ -1218,7 +1218,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             return
         }
         
-        // TODO: ここまで頑張って MediaChannel を持ってくる必要がある
         let dc = DataChannel(dataChannel: dataChannel, compress: compress, mediaChannel: mediaChannel, peerChannel: self.channel)
         channel.dataChannels += [dataChannel.label]
         channel.dataChannelInstances[dataChannel.label] = dc

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -150,9 +150,8 @@ public protocol PeerChannel: AnyObject {
     
     var signalingOfferMessageDataChannels: [[String: Any]] { get }
 
-    // DataChannel のコールバックを追加する際に、必要になった
-    // TODO: setter を外せないか確認する -> 外せなかった
-    var mediaChannel: MediaChannel? { get set }
+    // DataChannel のコールバックを追加する際に必要だった
+    var mediaChannel: MediaChannel? { get }
     // MARK: - インスタンスの生成
     
     /**
@@ -161,7 +160,7 @@ public protocol PeerChannel: AnyObject {
      - parameter configuration: クライアントの設定
      - parameter signalingChannel: 使用するシグナリングチャネル
      */
-    init(configuration: Configuration, signalingChannel: SignalingChannel)
+    init(configuration: Configuration, signalingChannel: SignalingChannel, mediaChannel: MediaChannel?)
     
     // MARK: - 接続
     
@@ -217,9 +216,10 @@ class BasicPeerChannel: PeerChannel {
     
     weak var mediaChannel: MediaChannel?
     
-    required init(configuration: Configuration, signalingChannel: SignalingChannel) {
+    required init(configuration: Configuration, signalingChannel: SignalingChannel, mediaChannel: MediaChannel?) {
         self.configuration = configuration
         self.signalingChannel = signalingChannel
+        self.mediaChannel = mediaChannel
         context = BasicPeerChannelContext(channel: self)
     }
     

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -175,7 +175,7 @@ public protocol PeerChannel: AnyObject {
     var streams: [MediaStream] { get }
     
     /// 接続状態
-    var state: SoraConnectionState { get }
+    var state: PeerChannelConnectionState { get }
     
     /// シグナリングチャネル
     var signalingChannel: SignalingChannel { get }
@@ -238,7 +238,7 @@ class BasicPeerChannel: PeerChannel {
         context.connectionId
     }
     
-    var state: SoraConnectionState {
+    var state: PeerChannelConnectionState {
         get {
             return context.state
         }
@@ -371,10 +371,10 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     }
     
     weak var channel: BasicPeerChannel!
-    var state: SoraConnectionState {
+    var state: PeerChannelConnectionState {
         get {
             let state = nativeChannel == nil ? RTCPeerConnectionState.new : nativeChannel.connectionState
-            return SoraConnectionState(state)
+            return PeerChannelConnectionState(state)
         }
     }
     

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -287,9 +287,8 @@ class BasicPeerChannel: PeerChannel {
         context.connect(handler: handler)
     }
     
-    // TODO: DisconnectReason を外部に出したくないが ... 内部では利用したい
     func disconnect(error: Error?, reason: DisconnectReason) {
-        context.disconnect(error: error, reason: .user)
+        context.disconnect(error: error, reason: reason)
     }
     
     fileprivate func terminateAllStreams() {
@@ -307,29 +306,17 @@ class BasicPeerChannel: PeerChannel {
 
 // type: disconnect の reason を判断するのに必要な情報を保持します。
 // internal enum DisconnectReason {
-public enum DisconnectReason {
+public enum DisconnectReason : String {
     case user
     case signalingFailure
     case internalError
     case peerConnectionStateFailed
-    case webSocket // onerror と onclose を切り分けたいが難しそうだった
+    case webSocket
+    case noError
     case unknown
     
     var description: String {
-        switch self {
-        case .user:
-            return "user"
-        case .signalingFailure:
-            return "signalingFailure"
-        case .internalError:
-            return "internalError"
-        case .peerConnectionStateFailed:
-            return "peerConnectionFailed"
-        case .webSocket:
-            return "webSocket"
-        case .unknown:
-            return "unknown"
-        }
+        return self.rawValue
     }
 }
 
@@ -991,7 +978,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     }
     
     func basicDisconnect(error: Error?, reason: DisconnectReason) {
-        Logger.debug(type: .peerChannel, message: "try disconnecting: error=> \(error != nil ? error?.localizedDescription : "nil"), reason => \(reason.description)")
+        Logger.debug(type: .peerChannel, message: "try disconnecting: error=> \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
         if let error = error {
             Logger.error(type: .peerChannel,
                          message: "error: \(error.localizedDescription)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1,7 +1,5 @@
-import Compression
 import Foundation
 import WebRTC
-import zlib
 
 /**
  ピアチャネルのイベントハンドラです。

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -304,8 +304,7 @@ class BasicPeerChannel: PeerChannel {
 
 // MARK: -
 
-// type: disconnect の reason を判断するのに必要な情報を保持します。
-// internal enum DisconnectReason {
+/// type: disconnect の reason を判断するのに必要な情報を保持します。
 public enum DisconnectReason : String {
     case user
     case signalingFailure

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -11,7 +11,7 @@ public final class ZLibUtil {
             return nil
         }
         
-        let bufferSize = 262_144
+        let bufferSize = 262_144 // TODO: 毎回確保するには大きいので何とかする
         let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         
         var sourceBuffer = [UInt8](input)
@@ -44,7 +44,7 @@ public final class ZLibUtil {
             return nil
         }
         
-        let bufferSize = 262_144
+        let bufferSize = 262_144 // TODO: 毎回確保するには大きいので何とかする
         let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         
         var sourceBuffer = [UInt8](input)

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -64,12 +64,16 @@ public final class PeerChannelHandlers {
     /// シグナリング受信時に呼ばれるクロージャー
     public var onReceiveSignaling: ((Signaling) -> Void)?
     
+    /// DataChannel の open 時に呼ばれるクロージャー
     public var onOpenDataChannel: ((String) -> Void)?
-    
+
+    /// DataChannel のメッセージ受信時に呼ばれるクロージャー
     public var onDataChannelMessage: ((String, Data) -> Void)?
-    
+
+    /// DataChannel の close 時に呼ばれるクロージャー
     public var onCloseDataChannel: ((String) -> Void)?
-    
+
+    /// DataChannel の bufferedAmount 変更時に呼ばれるクロージャー
     public var onDataChannelBufferedAmount: ((String, UInt64) -> Void)?
 
     /// 初期化します。
@@ -94,13 +98,17 @@ public final class PeerChannelInternalHandlers {
     
     /// シグナリング受信時に呼ばれるクロージャー
     public var onReceiveSignaling: ((Signaling) -> Void)?
-    
+
+    /// DataChannel の open 時に呼ばれるクロージャー
     public var onOpenDataChannel: ((String) -> Void)?
-    
+
+    /// DataChannel のメッセージ受信時に呼ばれるクロージャー
     public var onDataChannelMessage: ((String, Data) -> Void)?
-    
+
+    /// DataChannel の close 時に呼ばれるクロージャー
     public var onCloseDataChannel: ((String) -> Void)?
-    
+
+    /// DataChannel の bufferedAmount 変更時に呼ばれるクロージャー
     public var onDataChannelBufferedAmount: ((String, UInt64) -> Void)?
 
     /// 初期化します。

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -45,7 +45,7 @@ public final class ZLibUtil {
         sourceBuffer.removeFirst(2)
         
         // checksum も削除
-        let checksum = Array(sourceBuffer.suffix(4))
+        let checksum = Data(sourceBuffer.suffix(4))
         sourceBuffer.removeLast(4)
         
         let size = compression_decode_buffer(destinationBuffer, bufferSize,
@@ -60,7 +60,7 @@ public final class ZLibUtil {
         let data = Data(referencing: NSData(bytes: destinationBuffer, length: size))
         
         // checksum の検証
-        if calcAdler32(data) == Data(checksum) {
+        if calcAdler32(data) == checksum {
             return data
         }
         

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1022,8 +1022,12 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         case .failed:
             disconnect(error: SoraError.peerChannelError(reason: "peer connection state: failed"))
         case .connected:
-            // NOTE: RTCPeerConnectionState は connected -> disconencted -> connected などと遷移する可能性がある
-            // finishConnecting を複数回実行するとエラーになるので注意
+            // NOTE: RTCPeerConnectionState は connected -> disconencted -> connected などと遷移する可能性があるが、
+            // finishDoing は複数回実行するとエラーになるので注意
+            //
+            // 遷移のパターンは以下のページの Figure 2 Non-normative ICE transport state transition diagram という図を参照
+            // https://www.w3.org/TR/webrtc/#dom-rtcicetransportstate
+            // 図は (RTCPeerConnectionState ではなく) RTCIceTransportState のものなので注意
             if !connectedAtLeastOnce {
                 finishConnecting()
                 connectedAtLeastOnce = true

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -984,13 +984,14 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                          message: "error: \(error.localizedDescription)")
         }
                 
+        sendDisconnectMessageIfNeeded(reason: reason, error: error)
+        
         if configuration.isSender {
             terminateSenderStream()
         }
         channel.terminateAllStreams()
         nativeChannel.close()
         
-        sendDisconnectMessageIfNeeded(reason: reason, error: error)
         signalingChannel.disconnect(error: error, reason: reason)
                 
         Logger.debug(type: .peerChannel, message: "call onDisconnect")
@@ -1062,7 +1063,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                 Logger.warn(type: .peerChannel, message: "failed to down cast error to SoraError")
             }
         default:
-            // TODO: 全部まとめて INTERNAL-ERROR にする? 要確認
             break
         }
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1059,8 +1059,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                 default:
                     break
                 }
-            } else {
-                Logger.warn(type: .peerChannel, message: "failed to down cast error to SoraError")
             }
         default:
             break

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -810,6 +810,8 @@ extension Signaling: Codable {
             self = .push(try SignalingPush(from: decoder))
         case "re-offer":
             self = .reOffer(try SignalingReOffer(from: decoder))
+        case "switched":
+            self = .switched(try SignalingSwitched(from: decoder))
         default:
             throw SoraError.unknownSignalingMessageType(type: type)
         }
@@ -1299,6 +1301,19 @@ extension SignalingPong: Codable {
     
     public func encode(to encoder: Encoder) throws {
         // エンコードするプロパティはない
+    }
+    
+}
+
+extension SignalingSwitched: Decodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case ignore_disconnect_websocket
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ignoreDisconnectWebsocket = try container.decode(Bool.self, forKey: .ignore_disconnect_websocket)
     }
     
 }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -514,7 +514,7 @@ public struct SignalingPush {
  "switched" シグナリングメッセージを表します。
  */
 public struct SignalingSwitched {
-    public var ignoreDisconnectWebsocket: Bool?
+    public var ignoreDisconnectWebSocket: Bool?
 }
 
 /**
@@ -1313,7 +1313,7 @@ extension SignalingSwitched: Decodable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        ignoreDisconnectWebsocket = try container.decode(Bool.self, forKey: .ignore_disconnect_websocket)
+        ignoreDisconnectWebSocket = try container.decode(Bool.self, forKey: .ignore_disconnect_websocket)
     }
     
 }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -53,7 +53,7 @@ private func updateMetadata(signaling: Signaling, data: Data) -> Signaling {
 
     switch signaling {
     case .offer(var message):
-        // TODO: keys を if let ... に書き換えたい
+        // TODO: if json.keys.contains("key") を if let に書き換えたい
         if json.keys.contains("metadata") {
             message.metadata = json["metadata"]
         }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -124,7 +124,7 @@ public enum Signaling {
     case pong(SignalingPong)
     
     /// "disconnect" シグナリング
-    case disconnect
+    case disconnect(SignalingDisconnect)
     
     /// "pong" シグナリング
     case push(SignalingPush)
@@ -773,6 +773,10 @@ public struct SignalingPing {
  */
 public struct SignalingPong {}
 
+public struct SignalingDisconnect {
+    public var reason: String?
+}
+
 // MARK: -
 // MARK: Codable
 
@@ -847,8 +851,9 @@ extension Signaling: Codable {
             try message.encode(to: encoder)
         case .pong:
             try container.encode(MessageType.pong.rawValue, forKey: .type)
-        case .disconnect:
+        case .disconnect(let message):
             try container.encode(MessageType.disconnect.rawValue, forKey: .type)
+            try message.encode(to: encoder)
         default:
             throw SoraError.invalidSignalingMessage
         }
@@ -1310,6 +1315,24 @@ extension SignalingPong: Codable {
         // エンコードするプロパティはない
     }
     
+}
+
+/// :nodoc:
+extension SignalingDisconnect: Codable {
+    
+    enum CodingKeys: String, CodingKey {
+        case reason
+    }
+    
+    public init(from decoder: Decoder) throws {
+        throw SoraError.invalidSignalingMessage
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(reason, forKey: .reason)
+    }
+
 }
 
 extension SignalingSwitched: Decodable {

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -125,6 +125,9 @@ public enum Signaling {
     /// "pong" シグナリング
     case push(SignalingPush)
     
+    /// "switch" シグナリング
+    case switched(SignalingSwitched)
+    
     /// :nodoc:
     public static func decode(_ data: Data) -> Result<Signaling, Error> {
         do {
@@ -164,6 +167,8 @@ public enum Signaling {
             return "disconnect"
         case .push(_):
             return "push"
+        case .switched(_):
+            return "switched"
         }
     }
     
@@ -359,6 +364,9 @@ public struct SignalingConnect {
 
     /// :nodoc:
     public var environment: String?
+    
+    public var dataChannelSignaling: Bool?
+    public var ignoreDisconectWebSocket: Bool?
 
 }
 
@@ -500,6 +508,13 @@ public struct SignalingPush {
     /// プッシュ通知で送信される JSON データ
     public var data: Any? = {}
     
+}
+
+/**
+ "switched" シグナリングメッセージを表します。
+ */
+public struct SignalingSwitched {
+    public var ignoreDisconnectWebsocket: Bool?
 }
 
 /**
@@ -916,6 +931,8 @@ extension SignalingConnect: Codable {
         case sora_client
         case libwebrtc
         case environment
+        case data_channel_signaling
+        case ignore_disconnect_websocket
     }
     
     enum VideoCodingKeys: String, CodingKey {
@@ -947,7 +964,9 @@ extension SignalingConnect: Codable {
         try container.encodeIfPresent(soraClient, forKey: .sora_client)
         try container.encodeIfPresent(webRTCVersion, forKey: .libwebrtc)
         try container.encodeIfPresent(environment, forKey: .environment)
-
+        try container.encodeIfPresent(dataChannelSignaling, forKey: .data_channel_signaling)
+        try container.encodeIfPresent(ignoreDisconectWebSocket, forKey: .ignore_disconnect_websocket)
+        
         if videoEnabled {
             if videoCodec != .default || videoBitRate != nil {
                 var videoContainer = container

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -46,15 +46,19 @@ private func updateMetadata(signaling: Signaling, data: Data) -> Signaling {
         json = jsonObject as! [String: Any]
     } catch {
         // JSON のシリアライズが失敗した場合は、引数として渡された signaling をそのまま返し、処理を継続する
-        Logger.info(type: .signaling,
+        Logger.error(type: .signaling,
                   message: "updateMetadata failed. error: \(error.localizedDescription), data: \(data)")
         return signaling
     }
 
     switch signaling {
     case .offer(var message):
+        // TODO: keys を if let ... に書き換えたい
         if json.keys.contains("metadata") {
             message.metadata = json["metadata"]
+        }
+        if let dataChannels = json["data_channels"] as? [[String: Any]] {
+            message.dataChannels = dataChannels
         }
         return .offer(message)
     case .push(var message):
@@ -448,6 +452,9 @@ public struct SignalingOffer {
 
     /// エンコーディング
     public let encodings: [Encoding]?
+    
+    /// データ・チャンネルの設定
+    public var dataChannels: [[String: Any]] = []
 
 }
 

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -235,7 +235,6 @@ class BasicSignalingChannel: SignalingChannel {
             if let error = error {
                 Logger.debug(type: .signalingChannel,
                           message: "connecting failed (\(error))")
-                // TODO: WebSocket のエラー
                 self.disconnect(error: error, reason: .webSocket)
                 return
             }

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -201,8 +201,7 @@ class BasicSignalingChannel: SignalingChannel {
                 Logger.debug(type: .signalingChannel, message: "ignoreDisconnectWebSocket: \(self.ignoreDisconnectWebSocket)")
                 // ignoreDisconnectWebSocket == true の場合は、 WebSocketChannel 切断時に SignalingChannel を切断しない
                 if !self.ignoreDisconnectWebSocket {
-                    // TODO: WebSocket のエラー
-                    self.disconnect(error: error, reason: .webSocket)
+                    self.disconnect(error: error, reason: error != nil ? .webSocket : .noError)
                 }
             }
         }

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -113,6 +113,7 @@ public protocol SignalingChannel: AnyObject {
     var state: ConnectionState { get }
     
     var ignoreDisconnectWebSocket: Bool { get set }
+    var dataChannelSignaling: Bool { get set }
     // MARK: - イベントハンドラ
     
     /// イベントハンドラ
@@ -177,6 +178,7 @@ class BasicSignalingChannel: SignalingChannel {
     var webSocketChannelHandlers: WebSocketChannelHandlers = WebSocketChannelHandlers()
     
     var ignoreDisconnectWebSocket: Bool = false
+    var dataChannelSignaling: Bool = false
     
     var configuration: Configuration
     

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -428,7 +428,8 @@ public final class ConnectionTask {
     public func cancel() {
         if state == .connecting {
             Logger.debug(type: .mediaChannel, message: "connection task cancelled")
-            peerChannel?.disconnect(error: SoraError.connectionCancelled)
+            // reason: .user としているため、 cancel は SDK 内部で使用してはならない
+            peerChannel?.disconnect(error: SoraError.connectionCancelled, reason: .user)
             state = .canceled
         }
     }

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -170,7 +170,7 @@ class URLSessionWebSocketChannelContext: NSObject, URLSessionDelegate, URLSessio
             case .failure(let error):
                 Logger.debug(type: .webSocketChannel,
                              message: "failed to receive error => \(error.localizedDescription)")
-                weakSelf.disconnect(error: error)
+                weakSelf.disconnect(error: SoraError.webSocketError(error))
             }
         }
     }


### PR DESCRIPTION
## この PR の ToDo

- [x] DataChannel シグナリング対応 (label: signaling)
- [x] DataChannel シグナリング統計情報対応 (label: stats)
- [x] DataChannel シグナリング通知対応 (label: notify)
- [x] DataChannel シグナリング E2EE 対応 (label: e2ee)
- [x] DataChannel シグナリングプッシュ通知対応 (label: push)
- [x] DataChannel 利用時の compress / uncompress 対応
  - 最適化の余地あり => 今回はパス
  - 元々あまり大きくないので、最適化してどれくらいメリットがあるか不明
- [x] type: offer 時の data_channels 対応
- [x] WebSocket シグナリングの type: switched 対応
- [x] WebSocket シグナリングの inogre_disconnect_websocket 対応
- [x] DataChannel 経由の type: disconnect 対応
  - 要相談: DataChannel で type: disconnect メッセージを送信した直後に Sora iOS SDK が切断処理を実行しているのが気になる
- [x] type: disconnect 時の reason: 対応
- [x] protocol を修正した箇所の検討
  - PeerChannel と SignalingChannel の disconnect を修正した => この PR をマージした後検討する