### PR TITLE
type: offer に含まれる data_channels をチェックする

### DIFF
--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -365,7 +365,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             dataChannelSignaling: configuration.dataChannelSignaling,
             ignoreDisconectWebSocket: configuration.ignoreDisconnectWebSocket)
         
-        signalingChannel.dataChannelSignaling = configuration.dataChannelSignaling ?? false
         Logger.debug(type: .peerChannel, message: "send connect")
         signalingChannel.send(message: Signaling.connect(connect))
     }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -727,7 +727,11 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         case .offer(let offer):
             clientId = offer.clientId
             connectionId = offer.connectionId
-            channel.signalingOfferMessageDataChannels = offer.dataChannels
+            if let dataChannels = offer.dataChannels {
+                signalingChannel.dataChannelSignaling = true
+                channel.signalingOfferMessageDataChannels = dataChannels
+            }
+
             createAndSendAnswer(offer: offer)
         case .update(let update):
             if configuration.isMultistream {

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -454,7 +454,7 @@ public struct SignalingOffer {
     public let encodings: [Encoding]?
     
     /// データ・チャンネルの設定
-    public var dataChannels: [[String: Any]] = []
+    public var dataChannels: [[String: Any]]?
 
 }
 


### PR DESCRIPTION
## 変更内容

- type: offer に含まれる `data_channels` をチェックして dataChannelSignaling フラグを更新する処理が漏れていたので追加しました
- また、type: connect 時に、 Configuration の値を使って dataChannelSignaling フラグを設定していた処理は誤りだったので削除しました (= type: offer 時の値が参照されるべき)