### PR TITLE
DataChannel 関連のコールバックを整理する

### DIFF
--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -118,26 +118,10 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     
     func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
         Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState)")
-        
-        switch (dataChannel.readyState) {
-        case .open:
-            if let mediaChannel = mediaChannel, let handler = mediaChannel.handlers.onOpenDataChannel {
-                handler(mediaChannel, dataChannel.label)
-            }
-        case .closed:
-            if let mediaChannel = mediaChannel, let handler = mediaChannel.handlers.onCloseDataChannel {
-                handler(mediaChannel, dataChannel.label)
-            }
-        default:
-            break
-        }
     }
     
     func dataChannel(_ dataChannel: RTCDataChannel, didChangeBufferedAmount amount: UInt64) {
         Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), amount => \(amount)")
-        if let mediaChannel = mediaChannel, let handler = mediaChannel.handlers.onDataChannelBufferedAmount {
-            handler(mediaChannel, dataChannel.label, amount)
-        }
     }
     
     func dataChannel(_ dataChannel: RTCDataChannel, didReceiveMessageWith buffer: RTCDataBuffer) {

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -87,6 +87,23 @@ fileprivate class ZLibUtil {
     }
 }
 
+extension RTCDataChannelState: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .connecting:
+            return "connecting"
+        case .open:
+            return "open"
+        case .closing:
+            return "closing"
+        case .closed:
+            return "closed"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
 class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     
     let compress: Bool
@@ -100,7 +117,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     }
     
     func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
-        Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState.rawValue)")
+        Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState)")
         
         switch (dataChannel.readyState) {
         case .open:

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -102,10 +102,17 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
         Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState.rawValue)")
         
-        if dataChannel.readyState == RTCDataChannelState.closed {
+        switch (dataChannel.readyState) {
+        case .open:
+            if let mediaChannel = mediaChannel, let handler = mediaChannel.handlers.onOpenDataChannel {
+                handler(mediaChannel, dataChannel.label)
+            }
+        case .closed:
             if let mediaChannel = mediaChannel, let handler = mediaChannel.handlers.onCloseDataChannel {
                 handler(mediaChannel, dataChannel.label)
             }
+        default:
+            break
         }
     }
     

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -59,17 +59,11 @@ public final class MediaChannelHandlers {
     /// シグナリング受信時に呼ばれるクロージャー
     public var onReceiveSignaling: ((Signaling) -> Void)?
 
-    /// DataChannel の open 時に呼ばれるクロージャー
-    public var onOpenDataChannel: ((MediaChannel, String) -> Void)?
+    /// シグナリングが DataChannel 経由に切り替わったタイミングで呼ばれるクロージャー
+    public var onDataChannel: ((MediaChannel) -> Void)?
 
     /// DataChannel のメッセージ受信時に呼ばれるクロージャー
     public var onDataChannelMessage: ((MediaChannel, String, Data) -> Void)?
-
-    /// DataChannel の close 時に呼ばれるクロージャー
-    public var onCloseDataChannel: ((MediaChannel, String) -> Void)?
-
-    /// DataChannel の bufferedAmount 変更時に呼ばれるクロージャー
-    public var onDataChannelBufferedAmount: ((MediaChannel, String, UInt64) -> Void)?
     
     /// 初期化します。
     public init() {}

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -766,6 +766,10 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             if (signalingChannel.ignoreDisconnectWebSocket) {
                 signalingChannel.webSocketChannel.disconnect(error: nil)
             }
+
+            if let mediaChannel = channel.mediaChannel, let onDataChannel = mediaChannel.handlers.onDataChannel {
+                onDataChannel(mediaChannel)
+            }
         default:
             break
         }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1044,10 +1044,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         let dc = DataChannel(dataChannel: dataChannel, compress: compress, mediaChannel: mediaChannel, peerChannel: self.channel)
         channel.dataChannels += [dataChannel.label]
         channel.dataChannelInstances[dataChannel.label] = dc
-        
-        if let handler = mediaChannel.handlers.onOpenDataChannel {
-            handler(mediaChannel, dataChannel.label)
-        }
     }
 }
 


### PR DESCRIPTION
## 変更内容

- DataChannel 関連のコールバックを整理しました
  - onDataChannel を追加
    - 正確には、実装済みだった onOpenDataChannel の名前を変更し、仕様を変更しています
    - シグナリングが DataChannel 経由に切り替わったタイミングをコールバックでユーザーに伝えます
      - 内部的には type: switched のシグナリング・メッセージを受信したタイミングで発火する実装になっています
  - 不要と思われる onCloseDataChannel, onDataChannelBufferedAmount を削除しました
    - ユーザーから要望があれば追加を検討してはどうかと思います
- RTCDataChannelState がログ出力時に数字になっていたバグも併せて修正しました

---

<details>
<summary> 修正前の記述 </summary>

## 変更内容

修正前のコードは `MediaChannelHandlers.onOpenDataChannel` をブラウザ API の `RTCPeerConnection.ondatachannel` に相当するタイミングで実行していました

上記は特に深い意図をもって実装されていたわけではありません

DataChannel が利用可能になったタイミングをユーザーに伝えるためには、 `RTCDataChannel.onopen` に相当するタイミングで `MediaChannelHandlers.onOpenDataChannel` を実行することが適切だと考えたため、そのように修正しました

## 前提

- ブラウザの `RTCPeerConnection.ondatachannel` に相当する API はモバイル (= sd/objc, sdk/android) にもある
- モバイルには `RTCDataChannel.onopen` に相当する API が無く、 `RTCDataChannel.readyState` の更新時に呼ばれるコールバックが存在する
  - onopen, onclose 相当の処理を実装する場合、`dataChannelDidChangeState` を利用して必要がある
- iOS/Android SDK のユーザーに `RTCPeerConnection.ondatachannel` 相当の API を公開すべきか?
  - 公開しなくても良いのではないか?
    - DataChannel の保持は SDK 側でやるので、 `RTCPeerConnection.ondatachannel`が上がってもユーザーがやることがない

## 相談

- @szktty Sora の仕様を確認しましたが、 Sora から `type: switched` を受け取ったタイミングで全ての DataChannel が open したと考えて良いようです
  - onOpenDataChannel / onCloseDataChannel 自体を削除することも検討しても良いかもしれません
    - Sora 的には、個別の DataChannel の open/close でイベントがあがることに違和感があるようです
## 共有事項

- ~~(挙動に大きな影響は無いはずですが、) 念のため DataChannel シグナリングの接続周りを再度テストしていただきたいです~~ => 不要でした
- また、この PR で併せて `RTCDataChannelState の出力が数字になっていたのを文字列に変換する` 修正を行っています

</details>