### PR TITLE
audio = false 設定時のワークアラウンドの削除

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
     - `MediaChannel.native` を追加
     - `MediaChannel.webSocketChannel` を追加
     - @szktty @enm10k
+- [FIX] Sora 接続時に audioEnabled = false を設定すると answer 生成に失敗してしまう問題についてのワークアラウンドを削除する
+    - @miosakuma
 
 ## 2021.2.1
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -347,10 +347,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             videoEnabled: configuration.videoEnabled,
             videoCodec: configuration.videoCodec,
             videoBitRate: configuration.videoBitRate,
-            // WARN: video only では answer 生成に失敗するため、
-            // 音声トラックを使用しない方法で回避する
-            // audioEnabled: config.audioEnabled,
-            audioEnabled: true,
+            audioEnabled: configuration.audioEnabled,
             audioCodec: configuration.audioCodec,
             audioBitRate: configuration.audioBitRate,
             spotlightEnabled: configuration.spotlightEnabled,
@@ -932,18 +929,6 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         
         Logger.debug(type: .peerChannel, message: "add a stream")
         stream.audioTracks.first?.source.volume = MediaStreamAudioVolume.max
-        
-        // WARN: connect シグナリングで audio=false とすると answer の生成に失敗するため、
-        // 音声トラックを使用しない方法で回避する
-        if !configuration.audioEnabled {
-            Logger.debug(type: .peerChannel, message: "disable audio tracks")
-            let tracks = stream.audioTracks
-            for track in tracks {
-                track.source.volume = 0
-                stream.removeAudioTrack(track)
-            }
-        }
-        
         let stream = BasicMediaStream(peerChannel: self.channel,
                                       nativeStream: stream)
         channel.add(stream: stream)


### PR DESCRIPTION
過去の以下コミットを revert しています。
https://github.com/shiguredo/sora-ios-sdk/commit/dda15af52babbb1cbb86725c37fae6fa596172db#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457

過去、video = true, audio = false で接続できない不具合があったとのことですが、試してみたところ
audio = false で接続しても正常に動作するようでしたのでワークアラウンドを削除します。

以下のパターンで接続を行い、接続に問題がないことを確認しています。

- multistream : true, sendrecv
- multistream : true, recvonly
- multistream : true, sendonly
- multistream : false, recvonly
- multistream : false, sendonly