### PR TITLE
DataChannel.send(_:) が失敗した場合の処理を追加する

### DIFF
--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -154,15 +154,20 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
                 // NOTE: stats の型を Signaling.swift に定義していない
                 let reports = Statistics(contentsOf: $0).jsonObject
                 let json: [String: Any] = ["type": "stats",
-                                           "reports": reports]
+                                            "reports": reports]
+                
+                var data: Data?
                 do {
-                    let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+                    data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+                } catch {
+                    Logger.error(type: .dataChannel, message: "failed to encode stats data to json")
+                }
+                
+                if let data = data {
                     let ok = dc.send(data)
                     if !ok {
-                        Logger.error(type: .dataChannel, message: "DataChannel.send(_:) failed")
+                            Logger.error(type: .dataChannel, message: "failed to send stats data over DataChannel")
                     }
-                } catch {
-                    Logger.error(type: .dataChannel, message: "failed to encode statistic data to json")
                 }
             }
             

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -159,7 +159,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
                     let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
                     let ok = dc.send(data)
                     if !ok {
-                        Logger.warn(type: .dataChannel, message: "DataChannel.send(_:) returned false")
+                        Logger.error(type: .dataChannel, message: "DataChannel.send(_:) failed")
                     }
                 } catch {
                     Logger.error(type: .dataChannel, message: "failed to encode statistic data to json")

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -157,7 +157,10 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
                                            "reports": reports]
                 do {
                     let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
-                    dc.send(data)
+                    let ok = dc.send(data)
+                    if !ok {
+                        Logger.warn(type: .dataChannel, message: "DataChannel.send(_:) returned false")
+                    }
                 } catch {
                     Logger.error(type: .dataChannel, message: "failed to encode statistic data to json")
                 }
@@ -204,13 +207,13 @@ class DataChannel {
         return delegate.compress
     }
 
-    func send(_ data: Data) {
+    func send(_ data: Data) -> Bool {
         Logger.debug(type: .dataChannel, message: "\(String(describing:type(of: self))):\(#function): label => \(label), data => \(data.base64EncodedString())")
 
         guard let data = compress ? ZLibUtil.zip(data) : data else {
             Logger.error(type: .dataChannel, message: "failed to compress message")
-            return
+            return false
         }
-        native.sendData(RTCDataBuffer(data: data, isBinary: false))
+        return native.sendData(RTCDataBuffer(data: data, isBinary: false))
     }
 }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -701,7 +701,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                 let ok = dataChannel.send(data)
                 if !ok {
                     // re-answer の送信に失敗した場合はちゃんと catch の内容を実行したいので Error を投げる
-                    throw SoraError.peerChannelError(reason: "DataChannel.send(_:) returned false")
+                    throw SoraError.peerChannelError(reason: "DataChannel.send(_:) failed")
                 }
             } catch {
                 Logger.error(type: .peerChannel,
@@ -906,7 +906,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             let data = try JSONEncoder().encode(message)
             let ok = dataChannel.send(data)
             if !ok {
-                Logger.warn(type: .peerChannel, message: "DataChannel.send(_:) returned false")
+                Logger.error(type: .peerChannel, message: "DataChannel.send(_:) failed")
             }
         } catch {
             Logger.error(type: .peerChannel,


### PR DESCRIPTION
## 変更内容

- `DataChannel.send(_:)` が失敗した場合の処理を追加しました

## メモ

libwebrtc のコメントでは、以下のようなケースで `DataChannel.send(_:)` が失敗する (= false を返す) ようです
また、 bool ではなく、 RTCError を返すように修正してはどうか? という議論があるようです

```
 // Sends `data` to the remote peer. If the data can't be sent at the SCTP
  // level (due to congestion control), it's buffered at the data channel level,
  // up to a maximum of MaxSendQueueSize().
  // Returns false if the data channel is not in open state or if the send
  // buffer is full.
  // TODO(webrtc:13289): Return an RTCError with information about the failure.
  virtual bool Send(const DataBuffer& buffer) = 0;
```

https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/api/data_channel_interface.h;l=184-190;drc=01343031cd039eeb6168a60a311f697102dccda2