### PR TITLE
DataChannel 切断に伴う終了処理を実装する

### DIFF
--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -118,6 +118,15 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
     
     func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
         Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState)")
+        
+        if dataChannel.readyState == .closed {
+            if let peerChannel = peerChannel {
+                // DataChannel が切断されたタイミングで PeerChannel を切断する
+                // PeerChannel -> DataChannel の順に切断されるパターンも存在するが、
+                // PeerChannel.disconnect(error:reason:) 側で排他処理が実装されているため問題ない
+                peerChannel.disconnect(error: nil, reason: DisconnectReason.dataChannelClosed)
+            }
+        }
     }
     
     func dataChannel(_ dataChannel: RTCDataChannel, didChangeBufferedAmount amount: UInt64) {
@@ -206,6 +215,10 @@ class DataChannel {
     
     var label: String {
         return native.label
+    }
+    
+    var state: RTCDataChannelState {
+        return native.readyState
     }
     
     var compress: Bool {

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -216,11 +216,7 @@ class DataChannel {
     var label: String {
         return native.label
     }
-    
-    var state: RTCDataChannelState {
-        return native.readyState
-    }
-    
+
     var compress: Bool {
         return delegate.compress
     }

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -120,11 +120,11 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
         Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState)")
         
         if dataChannel.readyState == .closed {
-            if let peerChannel = peerChannel {
-                // DataChannel が切断されたタイミングで PeerChannel を切断する
-                // PeerChannel -> DataChannel の順に切断されるパターンも存在するが、
-                // PeerChannel.disconnect(error:reason:) 側で排他処理が実装されているため問題ない
-                peerChannel.disconnect(error: nil, reason: DisconnectReason.dataChannelClosed)
+            if let mediaChannel = mediaChannel {
+                // DataChannel が切断されたタイミングで MediaChannel を切断する
+                // MediaChannel -> DataChannel の順に切断されるパターンも存在するが、
+                // MediaChannel.internalDisconnect(error:reason:) 側で排他処理が実装されているため問題ない
+                mediaChannel.internalDisconnect(error: nil, reason: DisconnectReason.dataChannelClosed)
             }
         }
     }

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -120,11 +120,11 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
         Logger.debug(type: .dataChannel, message: "\(#function): label => \(dataChannel.label), state => \(dataChannel.readyState)")
         
         if dataChannel.readyState == .closed {
-            if let mediaChannel = mediaChannel {
-                // DataChannel が切断されたタイミングで MediaChannel を切断する
-                // MediaChannel -> DataChannel の順に切断されるパターンも存在するが、
-                // MediaChannel.internalDisconnect(error:reason:) 側で排他処理が実装されているため問題ない
-                mediaChannel.internalDisconnect(error: nil, reason: DisconnectReason.dataChannelClosed)
+            if let peerChannel = peerChannel {
+                // DataChannel が切断されたタイミングで PeerChannel を切断する
+                // PeerChannel -> DataChannel の順に切断されるパターンも存在するが、
+                // PeerChannel.disconnect(error:reason:) 側で排他処理が実装されているため問題ない
+                peerChannel.disconnect(error: nil, reason: DisconnectReason.dataChannelClosed)
             }
         }
     }

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -410,13 +410,13 @@ public final class MediaChannel {
         internalDisconnect(error: error, reason: .user)
     }
     
-    private func internalDisconnect(error: Error?, reason: DisconnectReason) {
+    internal func internalDisconnect(error: Error?, reason: DisconnectReason) {
         switch state {
         case .disconnecting, .disconnected:
             break
             
         default:
-            Logger.debug(type: .mediaChannel, message: "try disconnecting")
+            Logger.debug(type: .mediaChannel, message: "\(): try disconnecting")
             if let error = error {
                 Logger.error(type: .mediaChannel,
                              message: "error: \(error.localizedDescription)")

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -421,7 +421,7 @@ public final class MediaChannel {
             break
             
         default:
-            Logger.debug(type: .mediaChannel, message: "\(#function): try disconnecting")
+            Logger.debug(type: .mediaChannel, message: "try disconnecting")
             if let error = error {
                 Logger.error(type: .mediaChannel,
                              message: "error: \(error.localizedDescription)")

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -416,7 +416,7 @@ public final class MediaChannel {
             break
             
         default:
-            Logger.debug(type: .mediaChannel, message: "\(): try disconnecting")
+            Logger.debug(type: .mediaChannel, message: "\(#function): try disconnecting")
             if let error = error {
                 Logger.error(type: .mediaChannel,
                              message: "error: \(error.localizedDescription)")

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -131,8 +131,11 @@ public final class MediaChannel {
     }
     
     /// 接続状態
-    public var state: ConnectionState {
-        return ConnectionState(peerChannel.state)
+    public private(set) var state: ConnectionState = .disconnected {
+        didSet {
+            Logger.trace(type: .mediaChannel,
+                         message: "changed state from \(oldValue) to \(state)")
+        }
     }
     
     /// 接続中 (`state == .connected`) であれば ``true``
@@ -285,7 +288,7 @@ public final class MediaChannel {
                  timeout: Int = 30,
                  handler: @escaping (_ error: Error?) -> Void) -> ConnectionTask {
         let task = ConnectionTask()
-        if state == .connecting || state == .connected {
+        if state.isConnecting {
             handler(SoraError.connectionBusy(reason:
                 "MediaChannel is already connected"))
             task.complete()
@@ -307,6 +310,7 @@ public final class MediaChannel {
                               handler: @escaping (Error?) -> Void) {
         Logger.debug(type: .mediaChannel, message: "try connecting")
         _handler = handler
+        state = .connecting
         connectionStartTime = nil
         connectionTask.peerChannel = peerChannel
 
@@ -314,7 +318,9 @@ public final class MediaChannel {
             guard let weakSelf = self else {
                 return
             }
-            weakSelf.internalDisconnect(error: error, reason: reason)
+            if weakSelf.state == .connecting || weakSelf.state == .connected {
+                weakSelf.internalDisconnect(error: error, reason: reason)
+            }
             connectionTask.complete()
         }
         
@@ -322,7 +328,9 @@ public final class MediaChannel {
             guard let weakSelf = self else {
                 return
             }
-            weakSelf.internalDisconnect(error: error, reason: reason)
+            if weakSelf.state == .connecting || weakSelf.state == .connected {
+                weakSelf.internalDisconnect(error: error, reason: reason)
+            }
             connectionTask.complete()
         }
         
@@ -383,6 +391,7 @@ public final class MediaChannel {
                 return
             }
             Logger.debug(type: .mediaChannel, message: "did connect")
+            weakSelf.state = .connected
             handler(nil)
             Logger.debug(type: .mediaChannel, message: "call onConnect")
             weakSelf.internalHandlers.onConnect?(nil)
@@ -406,31 +415,32 @@ public final class MediaChannel {
         internalDisconnect(error: error, reason: .user)
     }
 
-    // 切断処理が重複して実行されることを防ぐためのフラグ
-    private var disconnectAlreadyExecuted: Bool = false
-
     func internalDisconnect(error: Error?, reason: DisconnectReason) {
-        guard disconnectAlreadyExecuted == false else {
-            Logger.debug(type: .mediaChannel, message: "\(#function): already disconnecting")
-            return
+        switch state {
+        case .disconnecting, .disconnected:
+            break
+            
+        default:
+            Logger.debug(type: .mediaChannel, message: "\(#function): try disconnecting")
+            if let error = error {
+                Logger.error(type: .mediaChannel,
+                             message: "error: \(error.localizedDescription)")
+            }
+
+            if state == .connecting {
+                executeHandler(error: error)
+            }
+
+            state = .disconnecting
+            connectionTimer.stop()
+            peerChannel.disconnect(error: error, reason: reason)
+            Logger.debug(type: .mediaChannel, message: "did disconnect")
+            state = .disconnected
+
+            Logger.debug(type: .mediaChannel, message: "call onDisconnect")
+            internalHandlers.onDisconnect?(error)
+            handlers.onDisconnect?(error)
         }
-        disconnectAlreadyExecuted = true
-        
-        Logger.debug(type: .mediaChannel, message: "\(#function): try disconnecting")
-        if let error = error {
-            Logger.error(type: .mediaChannel,
-                         message: "error: \(error.localizedDescription)")
-        }
-        
-        executeHandler(error: error)
-        
-        connectionTimer.stop()
-        peerChannel.disconnect(error: error, reason: reason)
-        Logger.debug(type: .mediaChannel, message: "did disconnect")
-        
-        Logger.debug(type: .mediaChannel, message: "call onDisconnect")
-        internalHandlers.onDisconnect?(error)
-        handlers.onDisconnect?(error)
     }
 }
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -818,7 +818,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     }
     
     func basicDisconnect(error: Error?, reason: DisconnectReason) {
-        Logger.debug(type: .peerChannel, message: "\(#function): try disconencting: error => \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
+        Logger.debug(type: .peerChannel, message: "\(#function): try disconnecting: error => \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
         if let error = error {
             Logger.error(type: .peerChannel,
                          message: "error: \(error.localizedDescription)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -818,7 +818,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     }
     
     func basicDisconnect(error: Error?, reason: DisconnectReason) {
-        Logger.debug(type: .peerChannel, message: "\(#function): try disconnecting: error => \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
+        Logger.debug(type: .peerChannel, message: "try disconnecting: error => \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
         if let error = error {
             Logger.error(type: .peerChannel,
                          message: "error: \(error.localizedDescription)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -136,6 +136,7 @@ enum DisconnectReason : String {
     case internalError
     case peerConnectionStateFailed
     case webSocket
+    case dataChannelClosed
     case noError
     case unknown
     
@@ -817,12 +818,12 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
     }
     
     func basicDisconnect(error: Error?, reason: DisconnectReason) {
-        Logger.debug(type: .peerChannel, message: "try disconnecting: error => \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
+        Logger.debug(type: .peerChannel, message: "\(#function): try disconencting: error => \(String(describing: error != nil ? error?.localizedDescription : "nil")), reason => \(reason)")
         if let error = error {
             Logger.error(type: .peerChannel,
                          message: "error: \(error.localizedDescription)")
         }
-                
+
         sendDisconnectMessageIfNeeded(reason: reason, error: error)
         
         if configuration.isSender {
@@ -898,6 +899,8 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
                     break
                 }
             }
+        case .dataChannelClosed:
+            Logger.warn(type: .peerChannel, message: "DataChannel was closed")
         default:
             break
         }


### PR DESCRIPTION
## 変更内容

- DataChannel 切断時に、 Sora との接続を終了する処理が漏れていたので実装しました
  - 参照: https://sora-doc.shiguredo.jp/SORA_CLIENT#4bd719
- PeerChannel の切断が MediaChannel に伝搬されなくなる不具合を修正しました
  - 開発時に埋め込んだ不具合をリリース前に修正した形です
  - PeerChannel と MediaChannel の state を共通化した際に発生した問題でした
    - 元に戻しました (= state の共通化を止めました)

## 動作確認

- DataChannel シグナリングを有効にして Sora に接続した後、 label: stats の DataChannel を切断する => Sora との接続が切断される
- 接続後、アプリケーション (~ sora-ios-sdk-quickstart) から切断する => `{"type":"disconnect","reason":"NO-ERROR"}⏎` が Sora に通知される