### PR TITLE
Feature/check formatter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE=
     - name: Check uncommitted unformatted code
-      run: ! ./lint-format.sh
+      run: |
+        ! ./lint-format.sh
   release:
     if: contains(github.ref, 'tags/v')
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE=
+    - name: Check uncommitted unformatted code
+      run: ! ./lint-format.sh
   release:
     if: contains(github.ref, 'tags/v')
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             PROVISIONING_PROFILE=
     - name: Check uncommitted unformatted code
       run: |
-        ! ./lint-format.sh
+        ./lint-format.sh
   release:
     if: contains(github.ref, 'tags/v')
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,13 @@ jobs:
       run: xcodebuild -version
     - name: Show CocoaPods Version
       run: pod --version
+    - name: Restore Pods
+      uses: actions/cache@v2
+      with:
+        path: Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
     - name: Install Dependences
       run: |
         pod repo update

--- a/.swiftformat
+++ b/.swiftformat
@@ -3,5 +3,6 @@
 --semicolons inline
 --trailingclosures
 --wrapparameters after-first
+--header strip
 
 --disable redundantInit,sortedSwitchCases,strongOutlets,unusedArguments,wrapSwitchCases

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,3 @@
---allman true
 --exclude Pods
 --indent 4
 --semicolons inline

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,3 +12,30 @@ disabled_rules:
   - line_length
   - type_body_length
   - weak_delegate
+  - opening_brace
+  - closing_brace
+  - anonymous_argument_in_multiline_closure
+  - conditional_returns_on_newline
+  - multiline_arguments
+  - multiline_arguments_brackets
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
+  - vertical_parameter_alignment
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace
+  - vertical_whitespace_between_cases
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - colon
+  - comma
+  - comment_spacing
+  - trailing_comma
+  - trailing_newline
+  - trailing_whitespace
+  - closure_parameter_position
+  - closure_end_indentation
+  - closure_spacing
+  - for_where
+  - large_tuple
+  - todo

--- a/lint-format.sh
+++ b/lint-format.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# ローカルで lint と formatter を実行するスクリプト
+# すでにフォーマット済みであれば終了ステータス 1 を返す
+# GitHub Actions では未フォーマット箇所の有無の確認に使う
+
+PODS_ROOT=Pods
+SRCROOT=.
+FORMAT=${PODS_ROOT}/SwiftFormat/CommandLineTool/swiftformat
+LINT=${PODS_ROOT}/SwiftLint/swiftlint
+
+# フォーマットの必要性を確認する
+# フォーマットの必要がなかったら終了ステータスを 1 にする
+! $FORMAT --lint $SRCROOT
+change=$?
+
+$FORMAT $SRCROOT
+$LINT --fix $SRCROOT
+$LINT $SRCROOT
+
+exit $change

--- a/lint-format.sh
+++ b/lint-format.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ローカルで lint と formatter を実行するスクリプト
-# すでにフォーマット済みであれば終了ステータス 1 を返す
+# 未フォーマットか lint でルール違反を検出したら終了ステータス 1 を返す
 # GitHub Actions では未フォーマット箇所の有無の確認に使う
 
 PODS_ROOT=Pods
@@ -10,12 +10,13 @@ FORMAT=${PODS_ROOT}/SwiftFormat/CommandLineTool/swiftformat
 LINT=${PODS_ROOT}/SwiftLint/swiftlint
 
 # フォーマットの必要性を確認する
-# フォーマットの必要がなかったら終了ステータスを 1 にする
-! $FORMAT --lint $SRCROOT
-change=$?
+$FORMAT --lint $SRCROOT
+format=$?
 
 $FORMAT $SRCROOT
 $LINT --fix $SRCROOT
-$LINT $SRCROOT
+$LINT --strict $SRCROOT
+lint=$?
 
-exit $change
+test $format -eq 0 -a $lint -eq 0
+exit $?


### PR DESCRIPTION
lint/formatter のルールと、 lint/formatter に関連する GitHub Actions のワークフローを修正します。

## 変更内容

- lint でチェックするルールのうち、フォーマットに関するルールを除外する
- lint/formatter のルールを現時点のコードに合わせる
- ローカルで lint/formatter を実行するスクリプトを追加する
- GitHub Actions: 未コミットの未フォーマットのコードがあればエラーにする
  - lint/formatter は Xcode でのビルド時にも実行されますが、その結果が未コミットの場合にエラーにします
- GitHub Actions: CocoaPods のライブラリをキャッシュし、ワークフローの実行を高速化します

## 備考

- 本 PR では既存のコードに lint/formatter を実行していないので、 GitHub Actions の実行はエラーになります。既存のコードの修正は開発上で都合のいいタイミングで行ってください。
- lint を実行するといくつかのルール違反の警告が出ますが、意図したルールなので問題ありません。都合のいいタイミングで修正してください。