### PR TITLE
WebRTC 96.4664.2.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [UPDATE] WebRTC 96.4664.2.0 に上げる
+    - @miosakuma
+
 ## 2021.3.0
 
 - [UPDATE] システム条件を変更する

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 import Foundation
 
-let file = "WebRTC-95.4638.3.0/WebRTC.xcframework.zip"
+let file = "WebRTC-96.4664.2.0/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -19,7 +19,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "2534f2c4810dae7189b1388b8d4069072a19033c0f09e5c292c9fc3a663c16c1"),
+            checksum: "667332530158da5e80cdf5a8c5a0b4c65ef15a2beef75819a1d7e65be597cf15"),
         .target(
             name: "Sora",
             dependencies: ["WebRTC", "Starscream"],

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ platform :ios, '12.1'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '95.4638.3.0'
+  pod 'WebRTC', '96.4664.2.0'
   pod 'Starscream', '4.0.4'
   pod 'SwiftLint'
   pod 'SwiftFormat/CLI'

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '95.4638.3.0'
+  s.dependency "WebRTC", '96.4664.2.0'
   s.dependency "Starscream", "4.0.4"
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -9,16 +9,16 @@ public struct SDKInfo {
  */
 public struct WebRTCInfo {
     /// WebRTC フレームワークのバージョン
-    public static let version = "M95"
+    public static let version = "M96"
     
     /// WebRTC フレームワークのコミットポジション
-    public static let commitPosition = "3"
+    public static let commitPosition = "2"
     
     /// WebRTC フレームワークのメンテナンスバージョン
     public static let maintenanceVersion = "0"
     
     /// WebRTC フレームワークのソースコードのリビジョン
-    public static let revision = "cbad18b147e06f27082e0ff9312aeed86e6632b6"
+    public static let revision = "7ec519c8297828cfcd4c3a3871837ed3008d577e"
     
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {


### PR DESCRIPTION
M96 アップデートです。
Swift Package Manager 及び CocoaPods でのインストール確認済みです。