### PR TITLE
BasicPeerChannelContext が PeerChannel を弱参照で保持するのを止める

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 
 - [CHANGE] スポットライトレガシーを削除する
     - @miosakuma
+- [FIX] RTCPeerConnectionState が .failed に遷移した際の切断処理中にクラッシュする問題を修正する
+    - BasicPeerChannelContext と PeerChannel の循環参照を防ぐために弱参照を利用していましたが、それが原因で BasicPeerChannelContext より先に PeerChannel が解放されるケースがあり、クラッシュの原因となっていました
+    - @enm10k
 
 ## 2021.3.0
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -180,7 +180,14 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
         }
     }
 
-    weak var channel: PeerChannel!
+    // PeerChannel と BasicPeerChannelContext の循環参照によるメモリー・リークを防ぐ意図で、
+    // BasicPeerChannelContext では PeerChannel を弱参照で保持していた
+    // しかし、先に PeerChannel が解放されて BasicPeerChannelContext が残るパターンがあり、
+    // その場合は basicDisconnect の途中で Implicitly Unwrapped Optional に伴うエラーが発生した
+    //
+    // この問題を解決するため、弱参照を強参照に変更し、 basicDisconnect の終了時に明示的に nil クリアする
+    var channel: PeerChannel!
+
     var state: PeerChannelConnectionState {
         let state = nativeChannel == nil ? RTCPeerConnectionState.new : nativeChannel.connectionState
         return PeerChannelConnectionState(state)
@@ -822,6 +829,7 @@ class BasicPeerChannelContext: NSObject, RTCPeerConnectionDelegate {
             onConnectHandler = nil
         }
 
+        channel = nil // 循環参照を防ぐために明示的に nil を代入する
         Logger.debug(type: .peerChannel, message: "did disconnect")
     }
 


### PR DESCRIPTION
## 変更内容

- #114 を修正するために、BasicPeerChannelContext が PeerChannel を保持する方法を変更しました