### PR TITLE
DataChannel のメモリー・リークを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 - [FIX] RTCPeerConnectionState が .failed に遷移した際の切断処理中にクラッシュする問題を修正する
     - BasicPeerChannelContext と PeerChannel の循環参照を防ぐために弱参照を利用していましたが、それが原因で BasicPeerChannelContext より先に PeerChannel が解放されるケースがあり、クラッシュの原因となっていました
     - @enm10k
+- [FIX] DataChannel クラスで利用しているデータ圧縮/復号処理にメモリー・リークがあったので修正する
+    - @enm10k
 
 ## 2021.3.0
 

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -20,6 +20,9 @@ private enum ZLibUtil {
         // https://www.rfc-editor.org/rfc/rfc8260.html
         let bufferSize = 262_144
         let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer {
+            destinationBuffer.deallocate()
+        }
 
         var sourceBuffer = [UInt8](input)
         let size = compression_encode_buffer(destinationBuffer, bufferSize,
@@ -73,7 +76,7 @@ private enum ZLibUtil {
             return nil
         }
 
-        let data = Data(referencing: NSData(bytes: destinationBuffer, length: size))
+        let data = Data(bytesNoCopy: destinationBuffer, count: size, deallocator: .free)
 
         let calculatedChecksum = data.withUnsafeBytes { (p: UnsafeRawBufferPointer) -> Data in
             let bytef = p.baseAddress!.assumingMemoryBound(to: Bytef.self)


### PR DESCRIPTION
## 変更内容

- UnsafeMutablePointer が適切に解放されていない問題を修正しました