### PR TITLE
不要な onConnectHandler の呼び出しを削除する

### DIFF
--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -222,11 +222,6 @@ class SignalingChannel {
             Logger.debug(type: .signalingChannel, message: "call onDisconnect")
             internalHandlers.onDisconnect?(error, reason)
 
-            if onConnectHandler != nil {
-                Logger.debug(type: .signalingChannel, message: "call connect(handler:)")
-                onConnectHandler!(error)
-            }
-
             connectedUrl = nil
             Logger.debug(type: .signalingChannel, message: "did disconnect")
         }


### PR DESCRIPTION
## 変更内容

- SignalingChannel の disconnect で onConnectHandler を呼ぶ処理が不要だったので削除しました

## 詳細

- SignalingChannel の onConnectHandler に nil を渡して実行すると、 Sora に `type: connect` メッセージを送信します https://github.com/shiguredo/sora-ios-sdk/blob/9f3d216fe4af766514102ba4815da467199b1347/Sora/PeerChannel.swift#L267-L277
  - 最新の master/develop ブランチを確認済み
- #120 の前は SignalingChannel の接続完了時に onConnectHandler が nil クリアされるため、 SignalingChannel の disconnect で onConnectHandler が実行されることはありませんでした
- #120 の後は、 onConnecthandler が nil クリアされなくなったため、常に onConnecthandler が実行される状態になっていました