### PR TITLE
VideoView に debugMode = true を設定した際にメモリー・リークが発生する問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,8 @@
     - @enm10k
 - [FIX] CameraVideoCapturer で force unwrapping していた箇所を修正する
     - @enm10k
+- [FIX] VideoView に debugMode = true を設定した際にメモリー・リークが発生する問題を修正する
+    - @szktty @enm10k
     
 ## 2021.3.1
 

--- a/Sora/VideoView.swift
+++ b/Sora/VideoView.swift
@@ -273,9 +273,9 @@ class VideoViewContentView: UIView {
                 }
 
                 frameCount = 0
-                debugMonitor = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-                    DispatchQueue.main.async {
-                        self.updateDebugInfo()
+                debugMonitor = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+                    DispatchQueue.main.async { [weak self] in
+                        self?.updateDebugInfo()
                     }
                 }
             } else {


### PR DESCRIPTION
## 変更内容

- VideoView に debugMode = true を設定した際にメモリー・リークが発生する問題を修正しました