### PR TITLE
DataChannel メッセージング機能のテストで見つかった問題を修正

### DIFF
--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -184,7 +184,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
             case "signaling", "push", "notify":
                 switch Signaling.decode(data) {
                 case let .success(signaling):
-                    peerChannel.handleSiganlingOverDataChannel(signaling)
+                    peerChannel.handleSignalingOverDataChannel(signaling)
                 case let .failure(error):
                     Logger.error(type: .dataChannel,
                                  message: "decode failed (\(error.localizedDescription)) => ")

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -155,7 +155,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
         if let message = String(data: data, encoding: .utf8) {
             Logger.info(type: .dataChannel, message: "received data channel message: \(String(describing: message))")
         }
-        
+
         // Sora から送られてきたメッセージ
         if !dataChannel.label.starts(with: "#") {
             switch dataChannel.label {

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -182,11 +182,12 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
             }
 
         case "signaling", "push", "notify":
-            do {
-                let signaling = try JSONDecoder().decode(Signaling.self, from: data)
+            switch Signaling.decode(data) {
+            case let .success(signaling):
                 peerChannel.handleSiganlingOverDataChannel(signaling)
-            } catch {
-                Logger.error(type: .dataChannel, message: "failed to handle siganling message")
+            case let .failure(error):
+                Logger.error(type: .dataChannel,
+                             message: "decode failed (\(error.localizedDescription)) => ")
             }
         case "e2ee":
             Logger.error(type: .dataChannel, message: "NOT IMPLEMENTED: label => \(dataChannel.label)")

--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -152,52 +152,49 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
             return
         }
 
-        guard let message = String(data: data, encoding: .utf8) else {
-            Logger.error(type: .dataChannel, message: "failed to convert data to message")
-            return
+        if let message = String(data: data, encoding: .utf8) {
+            Logger.info(type: .dataChannel, message: "received data channel message: \(String(describing: message))")
         }
-        Logger.info(type: .dataChannel, message: "received data channel message: \(String(describing: message))")
+        
+        // Sora から送られてきたメッセージ
+        if !dataChannel.label.starts(with: "#") {
+            switch dataChannel.label {
+            case "stats":
+                peerChannel.nativeChannel?.statistics {
+                    // NOTE: stats の型を Signaling.swift に定義していない
+                    let reports = Statistics(contentsOf: $0).jsonObject
+                    let json: [String: Any] = ["type": "stats",
+                                               "reports": reports]
 
-        switch dataChannel.label {
-        case "stats":
-            peerChannel.nativeChannel?.statistics {
-                // NOTE: stats の型を Signaling.swift に定義していない
-                let reports = Statistics(contentsOf: $0).jsonObject
-                let json: [String: Any] = ["type": "stats",
-                                           "reports": reports]
+                    var data: Data?
+                    do {
+                        data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+                    } catch {
+                        Logger.error(type: .dataChannel, message: "failed to encode stats data to json")
+                    }
 
-                var data: Data?
-                do {
-                    data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
-                } catch {
-                    Logger.error(type: .dataChannel, message: "failed to encode stats data to json")
-                }
-
-                if let data = data {
-                    let ok = dc.send(data)
-                    if !ok {
-                        Logger.error(type: .dataChannel, message: "failed to send stats data over DataChannel")
+                    if let data = data {
+                        let ok = dc.send(data)
+                        if !ok {
+                            Logger.error(type: .dataChannel, message: "failed to send stats data over DataChannel")
+                        }
                     }
                 }
-            }
 
-        case "signaling", "push", "notify":
-            switch Signaling.decode(data) {
-            case let .success(signaling):
-                peerChannel.handleSiganlingOverDataChannel(signaling)
-            case let .failure(error):
-                Logger.error(type: .dataChannel,
-                             message: "decode failed (\(error.localizedDescription)) => ")
-            }
-        case "e2ee":
-            Logger.error(type: .dataChannel, message: "NOT IMPLEMENTED: label => \(dataChannel.label)")
-        default:
-            // label が # から始まるメッセージング機能の場合、ログの出力は不要
-            if !dataChannel.label.starts(with: "#") {
+            case "signaling", "push", "notify":
+                switch Signaling.decode(data) {
+                case let .success(signaling):
+                    peerChannel.handleSiganlingOverDataChannel(signaling)
+                case let .failure(error):
+                    Logger.error(type: .dataChannel,
+                                 message: "decode failed (\(error.localizedDescription)) => ")
+                }
+            case "e2ee":
+                Logger.error(type: .dataChannel, message: "NOT IMPLEMENTED: label => \(dataChannel.label)")
+            default:
                 Logger.error(type: .dataChannel, message: "unknown data channel label: \(dataChannel.label)")
             }
         }
-
         if let mediaChannel = mediaChannel, let handler = mediaChannel.handlers.onDataChannelMessage {
             handler(mediaChannel, dataChannel.label, data)
         }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -778,7 +778,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         internalHandlers.onReceiveSignaling?(signaling)
     }
 
-    func handleSiganlingOverDataChannel(_ signaling: Signaling) {
+    func handleSignalingOverDataChannel(_ signaling: Signaling) {
         Logger.debug(type: .mediaStream, message: "handle signaling over DataChannel => \(signaling.typeName())")
         switch signaling {
         case let .reOffer(reOffer):
@@ -787,7 +787,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
             // 処理は不要
             break
         default:
-            Logger.error(type: .peerChannel, message: "unexpected siganling type => \(signaling.typeName())")
+            Logger.error(type: .peerChannel, message: "unexpected signaling type => \(signaling.typeName())")
         }
 
         Logger.debug(type: .peerChannel, message: "call onReceiveSignaling")


### PR DESCRIPTION
## 変更点

- DataChannel シグナリングを有効に設定した際、 MediaChannelHandlers.onReceiveSignaling で取得した SignalingPush.data が意図せぬ型に変換されていたので修正しました
- DataChannel のメッセージを全て文字列に変換してログに出力するコードがあったので修正しました
  - DataChannel メッセージング機能ではバイナリも送信することが可能です

## メモ

- 設定で空白文字を無視すると diff がみやすいです https://github.com/shiguredo/sora-ios-sdk/pull/130/files?diff=split&w=1