### PR TITLE
WebRTC 99.4844.1.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] WebRTC 99.4844.1.0 に上げる
+    - @miosakuma
 - [ADD] メッセージング機能に対応する
     - @enm10k
 - [CHANGE] DataChannel 経由で受信したメッセージのうち label が signaling, push, notify のものは `MediaChannelHandlers.onReceiveSignaling` が呼ばれるように修正する

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let file = "WebRTC-98.4758.0.0/WebRTC.xcframework.zip"
+let file = "WebRTC-99.4844.1.0/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "70d629675279887f3833d08f414d73a156183dd41751519557961512f7eae2e0"
+            checksum: "cfd75f4fc6eac05e9d410488efbb7e0064b3f342c29bb8163a6edb79ed79821d"
         ),
         .target(
             name: "Sora",

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '98.4758.0.0'
+  pod 'WebRTC', '99.4844.1.0'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,7 +5,7 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '95.4638.3.0'
+  pod 'WebRTC', '99.4844.1.0'
   pod 'SwiftLint', '0.45.1'
   pod 'SwiftFormat/CLI', '0.49.0'
 end

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '98.4758.0.0'
+  s.dependency "WebRTC", '99.4844.1.0'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -9,16 +9,16 @@ public enum SDKInfo {
  */
 public enum WebRTCInfo {
     /// WebRTC フレームワークのバージョン
-    public static let version = "M98"
+    public static let version = "M99"
 
     /// WebRTC フレームワークのコミットポジション
-    public static let commitPosition = "0"
+    public static let commitPosition = "1"
 
     /// WebRTC フレームワークのメンテナンスバージョン
     public static let maintenanceVersion = "0"
 
     /// WebRTC フレームワークのソースコードのリビジョン
-    public static let revision = "a6b138d6b4ef3a5b2c87f899b67f3b5c8dd3c002"
+    public static let revision = "81f4af57823c28c903b61b273e6fc2b87787b11b"
 
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {


### PR DESCRIPTION
libwebrtc のアップデートです。CocoaPods, Swift Pakcage Manager とも簡単に動作確認済みです。
まだ stable ではないのでギリギリまでマージしないでおいておきます。