### PR TITLE
WIP: Hotfix/change condition to relay websocket error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@
 - FIX
     - バグ修正
 
+## hotfix/change-condition-to-relay-websocket-error
+
+- [FIX] Sora との接続確立後に WebSocket のエラーが発生した場合、 エラーが正しく伝搬されず、終了処理が実行されないため修正する
+    - 接続確立後に WebSocket のエラーが発生した場合、 Sora との接続を切断して終了処理を行うのが正しい処理です
+    - 詳細な仕様は https://sora-doc.shiguredo.jp/SORA_CLIENT に記載されています
+    - @enm10k
+
 ## 2022.1.0
 
 - [UPDATE] システム条件を変更する

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -119,7 +119,8 @@ class SignalingChannel {
 
             // 最初に接続に成功した WebSocket 以外は無視する
             guard weakSelf.webSocketChannel == nil else {
-                // TODO: ここでも候補から削除した方が良い?
+                // ここで、無視した WebSocket を webSocketChannelCandidates から削除したくなるが、
+                // 最初に接続が成功した際に、 webSocketChannelCandidates をクリアする処理が実行されるため削除は不要
                 return
             }
 
@@ -128,15 +129,14 @@ class SignalingChannel {
             weakSelf.webSocketChannel = webSocketChannel
             weakSelf.connectedUrl = ws.url
 
-            // 採用された WebSocket 以外を切断してから webSocketChannelCandidates を破棄する
+            // 採用された WebSocket 以外を切断してから webSocketChannelCandidates をクリアする
             weakSelf.webSocketChannelCandidates.removeAll { $0 == webSocketChannel }
             weakSelf.webSocketChannelCandidates.forEach {
                 Logger.debug(type: .signalingChannel, message: "closeing connection to \(String(describing: $0.host))")
                 $0.disconnect(error: nil)
             }
-
-            // 候補を破棄する
             weakSelf.webSocketChannelCandidates.removeAll()
+
             weakSelf.state = .connected
 
             if weakSelf.onConnectHandler != nil {

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -141,13 +141,19 @@ class SignalingChannel {
             }
             Logger.info(type: .signalingChannel, message: "disconnected from \(String(describing: ws.host))")
 
-            // 接続に失敗した WebSocket が候補に残っている場合取り除く
-            weakSelf.webSocketChannelCandidates.removeAll { $0.url.absoluteURL == ws.url.absoluteURL }
-
-            if weakSelf.webSocketChannelCandidates.count == 0, weakSelf.webSocketChannel == nil {
-                Logger.info(type: .signalingChannel, message: "No WebSocket connection")
+            if weakSelf.state == .connected {
                 if !weakSelf.ignoreDisconnectWebSocket {
                     weakSelf.disconnect(error: error, reason: .webSocket)
+                }
+            } else {
+                // 接続に失敗した WebSocket が候補に残っている場合取り除く
+                weakSelf.webSocketChannelCandidates.removeAll { $0.url.absoluteURL == ws.url.absoluteURL }
+
+                if weakSelf.webSocketChannelCandidates.count == 0, weakSelf.webSocketChannel == nil {
+                    Logger.info(type: .signalingChannel, message: "failed to connect to Sora")
+                    if !weakSelf.ignoreDisconnectWebSocket {
+                        weakSelf.disconnect(error: error, reason: .webSocket)
+                    }
                 }
             }
         }

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -66,9 +66,9 @@ class SignalingChannel {
 
     // SignalingChannel で利用する WebSocket の候補
     //
-    // WebSocket が接続に失敗した場合、候補から削除される
+    // 接続に失敗した WebSocket は候補から削除される
     // SignalingChannel で利用する WebSocket が決定する前に候補が無くなった場合、
-    // Sora への接続に失敗しているため、切断処理が必要
+    // Sora への接続に失敗しているため、 MediaChannel の接続処理を終了する必要がある
     //
     // また、 SignalingChannel で利用する WebSocket が決定した場合にも空になる
     var webSocketChannelCandidates: [URLSessionWebSocketChannel] = []

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -65,8 +65,12 @@ class SignalingChannel {
     var webSocketChannel: URLSessionWebSocketChannel?
 
     // SignalingChannel で利用する WebSocket の候補
-    // WebSocket が接続に失敗した場合、候補から削除されます
-    // また、 SignalingChannel で利用する WebSocket が決定した場合は空になります
+    //
+    // WebSocket が接続に失敗した場合、候補から削除される
+    // SignalingChannel で利用する WebSocket が決定する前に候補が無くなった場合、
+    // Sora への接続に失敗しているため、切断処理が必要
+    //
+    // また、 SignalingChannel で利用する WebSocket が決定した場合にも空になる
     var webSocketChannelCandidates: [URLSessionWebSocketChannel] = []
 
     private var onConnectHandler: ((Error?) -> Void)?
@@ -119,8 +123,10 @@ class SignalingChannel {
 
             // 最初に接続に成功した WebSocket 以外は無視する
             guard weakSelf.webSocketChannel == nil else {
-                // ここで、無視した WebSocket を webSocketChannelCandidates から削除したくなるが、
-                // 最初に接続が成功した際に、 webSocketChannelCandidates をクリアする処理が実行されるため削除は不要
+                // (接続に失敗した WebSocket と同様に、) 無視した WebSocket を webSocketChannelCandidates から削除することを検討したが、不要と判断した
+                //
+                // 最初の WebSocket が接続に成功した際に webSocketChannelCandidates をクリアするため、
+                // 既に webSocketChannelCandidates が空になっていることが理由
                 return
             }
 


### PR DESCRIPTION
`この PR は hotfix のレビュー用なのでマージしないでください`

---

## 変更内容

- Sora との接続確立後に WebSocket のエラーが発生した場合、 エラーが正しく伝搬されず、終了処理が実行されないため修正しました
  - 接続確立後に WebSocket のエラーが発生した場合、 Sora との接続を切断して終了処理を行うのが正しい動作です (*1)

 *1 ... 参照: https://sora-doc.shiguredo.jp/SORA_CLIENT#ebd008