### PR TITLE
メッセージ送信時に DataChannel の readyState が .open であることをチェックする

### DIFF
--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -220,6 +220,10 @@ class DataChannel {
         delegate.compress
     }
 
+    var readyState: RTCDataChannelState {
+        native.readyState
+    }
+
     func send(_ data: Data) -> Bool {
         Logger.debug(type: .dataChannel, message: "\(String(describing: type(of: self))):\(#function): label => \(label), data => \(data.base64EncodedString())")
 

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -453,6 +453,12 @@ public final class MediaChannel {
         guard let dc = peerChannel.dataChannels[label] else {
             return SoraError.messagingError(reason: "no DataChannel found: label => \(label)")
         }
+
+        let readyState = dc.readyState
+        guard readyState == .open else {
+            return SoraError.messagingError(reason: "readyState of the DataChannel is not open: label => \(label), readyState => \(readyState)")
+        }
+
         let result = dc.send(data)
 
         return result ? nil : SoraError.messagingError(reason: "failed to send message: label => \(label)")


### PR DESCRIPTION
## 変更内容

- MediaChannel.sendMessage に DataChannel.readyState が .open であることをチェックする処理を追加しました