### PR TITLE
[DO NOT MERGE] RTCPeerConnection で接続を行う箇所を同一の直列キューで処理する

### DIFF
--- a/Sora/DataChannel.swift
+++ b/Sora/DataChannel.swift
@@ -160,7 +160,7 @@ class BasicDataChannelDelegate: NSObject, RTCDataChannelDelegate {
         if !dataChannel.label.starts(with: "#") {
             switch dataChannel.label {
             case "stats":
-                peerChannel.nativeChannel?.statistics {
+                peerChannel.statistics {
                     // NOTE: stats の型を Signaling.swift に定義していない
                     let reports = Statistics(contentsOf: $0).jsonObject
                     let json: [String: Any] = ["type": "stats",

--- a/Sora/SoraDispatcher.swift
+++ b/Sora/SoraDispatcher.swift
@@ -2,11 +2,17 @@ import WebRTC
 
 /// libwebrtc の内部で利用されているキューを表します。
 public enum SoraDispatcher {
+
+    static var peerConnectionQueue = DispatchQueue(label: "SoraDispatcher.peerConnection", qos: .utility)
+
     /// カメラ用のキュー
     case camera
 
     /// 音声処理用のキュー
     case audio
+
+    // RTCPeerConnection 用のキュー
+    case peerConnection
 
     /// 指定されたキューを利用して、 block を非同期で実行します。
     public static func async(on queue: SoraDispatcher, block: @escaping () -> Void) {
@@ -14,9 +20,12 @@ public enum SoraDispatcher {
         switch queue {
         case .camera:
             native = .typeCaptureSession
+            RTCDispatcher.dispatchAsync(on: native, block: block)
         case .audio:
             native = .typeAudioSession
+            RTCDispatcher.dispatchAsync(on: native, block: block)
+        case .peerConnection:
+            SoraDispatcher.peerConnectionQueue.async(execute: block)
         }
-        RTCDispatcher.dispatchAsync(on: native, block: block)
     }
 }


### PR DESCRIPTION
接続と切断を短時間で行った場合にクラッシュする現象を修正する試験的な実装です。変更内容は以下の通りです。

- RTCPeerConnection で接続と切断を行う箇所をグローバルな同一の直列キューで処理する
  - 念のため、統計情報の取得も同一のキューで処理する
- SoraDispatcher に上記のキューを追加する

本 PR は試験的な実装です。この実装が適切な修正方法とは限らないので、マージは行わないでください。