### PR TITLE
対応アーキテクチャから x86_64 を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,14 @@
 - [CHANGE] bitcode を無効にする
     - WebRTC 105.5195.0.0 より bitcode が廃止になりました。bitcode を無効にしてビルドをする必要があります
     - @miosakuma
+- [CHANGE] 対応アーキテクチャから x86_64 を無効にする
+    - @miosakuma
 - [UPDATE] WebRTC 105.5195.0.0 に上げる
+    - @miosakuma
+- [UPDATE] システム条件を変更する
+    - macOS 12.6 以降
+    - Xcode 14.0
+    - Swift 5.7
     - @miosakuma
 
 ## 2022.5.0

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Please read https://github.com/shiguredo/oss before use.
 ## システム条件
 
 - iOS 13 以降
-- アーキテクチャ arm64, x86_64 (シミュレーターの動作は未保証)
-- macOS 12.3 以降
-- Xcode 13.4.1
-- Swift 5.6.1
+- アーキテクチャ arm64 (シミュレーターの動作は未保証)
+- macOS 12.6 以降
+- Xcode 14.0
+- Swift 5.7
 - CocoaPods 1.11.2 以降
 - WebRTC SFU Sora 2022.1.1 以降
 

--- a/Sora.xcodeproj/project.pbxproj
+++ b/Sora.xcodeproj/project.pbxproj
@@ -510,7 +510,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 x86_64";
+				VALID_ARCHS = arm64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -568,7 +568,7 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 x86_64";
+				VALID_ARCHS = arm64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -603,7 +603,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
-				VALID_ARCHS = "arm64 x86_64";
+				VALID_ARCHS = arm64;
 			};
 			name = Debug;
 		};
@@ -635,7 +635,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
-				VALID_ARCHS = "arm64 x86_64";
+				VALID_ARCHS = arm64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
WebRTC 105.5195.0.0 から macOS x86_64 がビルド対象から外れたことに伴い、Sora iOS SDK も x86_64 を対象外としています。

sora-ios-sdk-quickstart がこのブランチを使用して MacBook Air (M1, 2020) で動作していることを確認しています。