### PR TITLE
[CI] GitHub Actions のバージョンアップ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Select Xcode Version
       run: sudo xcode-select -s '${{ env.XCODE }}/Contents/Developer'
     - name: Show Xcode Version
@@ -25,7 +25,7 @@ jobs:
     - name: Show CocoaPods Version
       run: pod --version
     - name: Restore Pods
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: Pods
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -55,7 +55,7 @@ jobs:
   release:
     if: contains(github.ref, 'tags/v')
     needs: [build]
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
以下で発生していた GitHub Actions のワーニング対応です。
Node.js 16 に対応している最新版にしています。ワーニングがなくなったことで OK としています。

https://github.com/shiguredo/sora-ios-sdk/actions/runs/3406564919