### PR TITLE
m107.5304.4.1  にてシグナリング時にクラッシュする事象を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+- [FIX] m107.5304.4.1 の利用時、シグナリング時に EXEC_BAD_ACCESS が発生する事象を修正する
+    - `RTCPeerConnection.offer()` に渡すブロック内で `RTCPeerConnection.close()` を呼んでいるのが原因だと思われるため、 async/await を使って offer() の終了を待ってから close() する
+    - `RTCPeerConnection.offer()` の実行が非同期で行われるようになるが、 `NativePeerChannelFactory.createClientOfferSDP()` の用途では問題ない
+    - @szktty
+
 ## 2022.6.0
 
 - [CHANGE] bitcode を無効にする

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -148,11 +148,12 @@ class NativePeerChannelFactory {
                                               constraints: constraints)
         peer2.add(stream.videoTracks[0], streamIds: [stream.streamId])
         peer2.add(stream.audioTracks[0], streamIds: [stream.streamId])
-        peer2.offer(for: constraints.nativeValue) { sdp, error in
-            if let error = error {
-                handler(nil, error)
-            } else if let sdp = sdp {
+        Task {
+            do {
+                let sdp = try await peer2.offer(for: constraints.nativeValue)
                 handler(sdp.sdp, nil)
+            } catch {
+                handler(nil, error)
             }
             peer2.close()
         }


### PR DESCRIPTION
m107.5304.4.1 の利用時、シグナリング時に EXEC_BAD_ACCESS が発生する事象を修正します。

`RTCPeerConnection.offer()` に渡すブロック内で `RTCPeerConnection.close()` を呼んでいるのが原因だと思われます。そのため、 async/await を使って `offer()` の終了を待ってから `close()` するよう変更します。

この変更により、  `peer2.offer()` の実行が非同期で行われるようになります。ただし、 `NativePeerChannelFactory.createClientOfferSDP()` の用途では問題ありません。