### PR TITLE
 Configuration に audioStreamingLanguageCode を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] WebRTC 109.5414.2.0 に上げる
     - @miosakuma
+- [UPDATE] Configuration に audioStreamingLanguageCode を追加する
+    - @miosakuma
 - [FIX] m107.5304.4.1 の利用時、シグナリング時に EXEC_BAD_ACCESS が発生する事象を修正する
     - `RTCPeerConnection.offer()` に渡すブロック内で `RTCPeerConnection.close()` を呼んでいるのが原因だと思われるため、 async/await を使って offer() の終了を待ってから close() する
     - `RTCPeerConnection.offer()` の実行が非同期で行われるようになるが、 `NativePeerChannelFactory.createClientOfferSDP()` の用途では問題ない

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [UPDATE] WebRTC 109.5414.2.0 に上げる
     - @miosakuma
-- [UPDATE] Configuration に audioStreamingLanguageCode を追加する
+- [ADD] Configuration に audioStreamingLanguageCode を追加する
     - @miosakuma
 - [FIX] m107.5304.4.1 の利用時、シグナリング時に EXEC_BAD_ACCESS が発生する事象を修正する
     - `RTCPeerConnection.offer()` に渡すブロック内で `RTCPeerConnection.close()` を呼んでいるのが原因だと思われるため、 async/await を使って offer() の終了を待ってから close() する

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -210,6 +210,9 @@ public struct Configuration {
     /// 詳細: https://sora-doc.shiguredo.jp/DATA_CHANNEL_SIGNALING#07c227
     public var ignoreDisconnectWebSocket: Bool?
 
+    /// 音声ストリーミング機能で利用する言語コード
+    public var audioStreamingLanguageCode: String?
+
     /// プロキシに関する設定
     public var proxy: Proxy?
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -317,6 +317,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
             environment: DeviceInfo.current.description,
             dataChannelSignaling: configuration.dataChannelSignaling,
             ignoreDisconnectWebSocket: configuration.ignoreDisconnectWebSocket,
+            audioStreamingLanguageCode: configuration.audioStreamingLanguageCode,
             redirect: redirect
         )
 

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -364,6 +364,9 @@ public struct SignalingConnect {
     /// DataChannel 経由のシグナリングを有効にした際、 WebSocket の接続が切れても Sora との接続を切断しない
     public var ignoreDisconnectWebSocket: Bool?
 
+    /// 音声ストリーミング機能で利用する言語コード
+    public var audioStreamingLanguageCode: String?
+
     /// type: redicret 受信後の再接続
     public var redirect: Bool?
 }
@@ -833,6 +836,7 @@ extension SignalingConnect: Codable {
         case data_channel_signaling
         case ignore_disconnect_websocket
         case data_channels
+        case audio_streaming_language_code
         case redirect
     }
 
@@ -868,6 +872,7 @@ extension SignalingConnect: Codable {
         try container.encodeIfPresent(environment, forKey: .environment)
         try container.encodeIfPresent(dataChannelSignaling, forKey: .data_channel_signaling)
         try container.encodeIfPresent(ignoreDisconnectWebSocket, forKey: .ignore_disconnect_websocket)
+        try container.encodeIfPresent(audioStreamingLanguageCode, forKey: .audio_streaming_language_code)
         try container.encodeIfPresent(redirect, forKey: .redirect)
 
         if videoEnabled {


### PR DESCRIPTION
Sora iOS SDK に `audio_streaming_language_code` を追加する対応です。
https://sora-doc.shiguredo.jp/AUDIO_STREAMING#a8b9a3

動作確認はできていますが、不備等ないかご確認をお願いします。