### PR TITLE
映像解像度に 3840x2160 を追加する

### DIFF
--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -386,6 +386,9 @@ public struct CameraSettings: CustomStringConvertible {
         /// UHD 2160p, 3840x2160
         case uhd2160p
 
+        /// UHD 3024p, 4032x3024
+        case uhd3024p
+
         /// 横方向のピクセル数を返します。
         public var width: Int32 {
             switch self {
@@ -394,6 +397,7 @@ public struct CameraSettings: CustomStringConvertible {
             case .hd720p: return 1280
             case .hd1080p: return 1920
             case .uhd2160p: return 3840
+            case .uhd3024p: return 4032
             }
         }
 
@@ -405,6 +409,7 @@ public struct CameraSettings: CustomStringConvertible {
             case .hd720p: return 720
             case .hd1080p: return 1080
             case .uhd2160p: return 2160
+            case .uhd3024p: return 3024
             }
         }
     }

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -383,7 +383,7 @@ public struct CameraSettings: CustomStringConvertible {
         /// HD 1080p, 1920x1080
         case hd1080p
 
-        /// UHD 1080p, 3840x2160
+        /// UHD 2160p, 3840x2160
         case uhd2160p
 
         /// 横方向のピクセル数を返します。

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -383,6 +383,9 @@ public struct CameraSettings: CustomStringConvertible {
         /// HD 1080p, 1920x1080
         case hd1080p
 
+        /// UHD 1080p, 3840x2160
+        case uhd2160p
+
         /// 横方向のピクセル数を返します。
         public var width: Int32 {
             switch self {
@@ -390,6 +393,7 @@ public struct CameraSettings: CustomStringConvertible {
             case .vga480p: return 640
             case .hd720p: return 1280
             case .hd1080p: return 1920
+            case .uhd2160p: return 3840
             }
         }
 
@@ -400,6 +404,7 @@ public struct CameraSettings: CustomStringConvertible {
             case .vga480p: return 480
             case .hd720p: return 720
             case .hd1080p: return 1080
+            case .uhd2160p: return 2160
             }
         }
     }


### PR DESCRIPTION
3840x2160 の解像度を増やす PR です。
ローカルネットワーク内ではこの解像度の送信に成功しています。

変数名は `uhd2160p` にしています。

気になる点 1
---

iPhone の設定画面では 4K という表記を使っていますが、数字先頭の変数名を使えないことや、今までの変数名と合わせた表記としてこの変数名にしています。

気になる点 2
---

`4032x3024` の解像度でも送信はできたものの、iOS 独自のサイズであまり一般的な解像度と思えなかったため追加をしていません。
現在の最大解像度なので次世代にもっと一般的な解像度が出るのではないかと判断しました。
追加してもよいのではなどご意見あればお聞きしたいです。
