### PR TITLE
サイマルキャストが VP9 / AVI で動作しない事象を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] WebRTC 114.5735.2.2 に上げる
+    - @szktty
 - [UPDATE] 転送フィルター機能を追加する
   - [ADD] `Configuration` に `forwardingFilter` を追加する
     - @szktty

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - [UPDATE] 転送フィルター機能を追加する
   - [ADD] `Configuration` に `forwardingFilter` を追加する
     - @szktty
+- [FIX] サイマルキャストが VP9 / AV1 で動作しない事象を修正する
+    - @szktty
 
 ## 2023.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - [UPDATE] 転送フィルター機能を追加する
   - [ADD] `Configuration` に `forwardingFilter` を追加する
     - @szktty
-- [FIX] サイマルキャストが VP9 / AV1 で動作しない事象を修正する
+- [CHANGE] サイマルキャストが VP9 / AV1 で動作しない事象を修正する
     - @szktty
 
 ## 2023.1.0

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '112.5615.1.0'
+  pod 'WebRTC', '114.5735.2.2'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,7 +5,7 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '112.5615.1.0'
+  pod 'WebRTC', '114.5735.2.2'
   pod 'SwiftLint', '0.51.0'
   pod 'SwiftFormat/CLI', '0.51.6'
 end

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '112.5615.1.0'
+  s.dependency "WebRTC", '114.5735.2.2'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1166,12 +1166,12 @@ extension RTCRtpSender {
                 }
 
                 if let value = encoding.maxBitrate {
-                    Logger.debug(type: .peerChannel, message: "maxBitrate: \(value))")
+                    Logger.debug(type: .peerChannel, message: "maxBitrate: \(value)")
                     oldEncoding.maxBitrateBps = NSNumber(value: value)
                 }
 
                 if let value = encoding.scaleResolutionDownBy {
-                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownBy: \(value))")
+                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownBy: \(value)")
                     oldEncoding.scaleResolutionDownBy = NSNumber(value: value)
                 }
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1175,6 +1175,11 @@ extension RTCRtpSender {
                     oldEncoding.scaleResolutionDownBy = NSNumber(value: value)
                 }
 
+                if let value = encoding.scalabilityMode {
+                    Logger.debug(type: .peerChannel, message: "scalabilityMode: \(value)")
+                    oldEncoding.scalabilityMode = value;
+                }
+
                 break
             }
         }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -568,9 +568,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
             if isSender {
                 if initialOffer {
                     self.initializeSenderStream(mid: mid)
-                } else {
-                    self.updateSenderOfferEncodings()
                 }
+                self.updateSenderOfferEncodings()
             }
 
             Logger.debug(type: .peerChannel, message: "try creating native answer")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1176,7 +1176,7 @@ extension RTCRtpSender {
 
                 if let value = encoding.scalabilityMode {
                     Logger.debug(type: .peerChannel, message: "scalabilityMode: \(value)")
-                    oldEncoding.scalabilityMode = value;
+                    oldEncoding.scalabilityMode = value
                 }
 
                 break

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -412,6 +412,9 @@ public struct SignalingOffer {
         /// 映像解像度を送信前に下げる度合
         public let scaleResolutionDownBy: Double?
 
+        /// scalability mode
+        public let scalabilityMode: String?
+
         /// RTP エンコーディングに関するパラメーター
         public var rtpEncodingParameters: RTCRtpEncodingParameters {
             let params = RTCRtpEncodingParameters()
@@ -425,6 +428,7 @@ public struct SignalingOffer {
             if let value = scaleResolutionDownBy {
                 params.scaleResolutionDownBy = NSNumber(value: value)
             }
+            params.scalabilityMode = scalabilityMode
             return params
         }
     }
@@ -964,6 +968,7 @@ extension SignalingOffer.Encoding: Codable {
         case maxBitrate
         case maxFramerate
         case scaleResolutionDownBy
+        case scalabilityMode
     }
 
     public init(from decoder: Decoder) throws {
@@ -974,6 +979,8 @@ extension SignalingOffer.Encoding: Codable {
         maxFramerate = try container.decodeIfPresent(Double.self, forKey: .maxFramerate)
         scaleResolutionDownBy = try container.decodeIfPresent(Double.self,
                                                               forKey: .scaleResolutionDownBy)
+        scalabilityMode = try container.decodeIfPresent(String.self,
+            forKey: .scalabilityMode)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -980,7 +980,7 @@ extension SignalingOffer.Encoding: Codable {
         scaleResolutionDownBy = try container.decodeIfPresent(Double.self,
                                                               forKey: .scaleResolutionDownBy)
         scalabilityMode = try container.decodeIfPresent(String.self,
-            forKey: .scalabilityMode)
+                                                        forKey: .scalabilityMode)
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
libwebrtc を m113 以降にアップデートする際、サイマルキャストが VP9 および AV1 で動作しない事象を修正します。

## 注意

- scalability mode 対応パッチを適用した libwebrtc のバイナリが必要です。そのため、現在の Podfile の設定では GitHub Actions でのビルドに失敗します
  - https://github.com/shiguredo-webrtc-build/webrtc-build/pull/49
- webrtc-build の次のリリースを待ってからマージしてください

## 変更点

- type: offer で受信した scalability mode を RTCRtpEncodingParameter にセットする

