### PR TITLE
映像コーデックパラメーターを指定可能とする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
 - [UPDATE] 転送フィルター機能を追加する
   - [ADD] `Configuration` に `forwardingFilter` を追加する
     - @szktty
+- [ADD] 映像コーデックパラメーターの設定を追加する
+    - `Configuration` に `videoVp9Params`, `videoAv1Params`, `videoH264Params` を追加する
+    - @miosakuma
 - [CHANGE] サイマルキャストが VP9 / AV1 で動作しない事象を修正する
     - @szktty
 

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -219,6 +219,15 @@ public struct Configuration {
     /// 転送フィルターの設定
     public var forwardingFilter: ForwardingFilter?
 
+    /// VP9 向け映像コーデックパラメーター
+    public var videoVp9Params: Encodable?
+
+    /// AV1 向け映像コーデックパラメーター
+    public var videoAv1Params: Encodable?
+
+    /// H264 向け映像コーデックパラメーター
+    public var videoH264Params: Encodable?
+
     // MARK: - イベントハンドラ
 
     /// WebSocket チャネルに関するイベントハンドラ

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -319,7 +319,10 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
             ignoreDisconnectWebSocket: configuration.ignoreDisconnectWebSocket,
             audioStreamingLanguageCode: configuration.audioStreamingLanguageCode,
             redirect: redirect,
-            forwardingFilter: configuration.forwardingFilter
+            forwardingFilter: configuration.forwardingFilter,
+            vp9Params: configuration.videoVp9Params,
+            av1Params: configuration.videoAv1Params,
+            h264Params: configuration.videoH264Params
         )
 
         Logger.debug(type: .peerChannel, message: "send connect")

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -372,6 +372,15 @@ public struct SignalingConnect {
 
     /// 転送フィルターの設定
     public var forwardingFilter: ForwardingFilter?
+
+    /// VP9 向け映像コーデックパラメーター
+    public var vp9Params: Encodable?
+
+    /// AV1 向け映像コーデックパラメーター
+    public var av1Params: Encodable?
+
+    /// H264 向け映像コーデックパラメーター
+    public var h264Params: Encodable?
 }
 
 /**
@@ -851,6 +860,9 @@ extension SignalingConnect: Codable {
     enum VideoCodingKeys: String, CodingKey {
         case codec_type
         case bit_rate
+        case vp9_params
+        case av1_params
+        case h264_params
     }
 
     enum AudioCodingKeys: String, CodingKey {
@@ -894,6 +906,18 @@ extension SignalingConnect: Codable {
                 }
                 try videoContainer.encodeIfPresent(videoBitRate,
                                                    forKey: .bit_rate)
+                if let vp9Params = vp9Params {
+                    let vp9ParamsEnc = videoContainer.superEncoder(forKey: .vp9_params)
+                    try vp9Params.encode(to: vp9ParamsEnc)
+                }
+                if let av1Params = av1Params {
+                    let av1ParamsEnc = videoContainer.superEncoder(forKey: .av1_params)
+                    try av1Params.encode(to: av1ParamsEnc)
+                }
+                if let h264Params = h264Params {
+                    let h264ParamsEnc = videoContainer.superEncoder(forKey: .h264_params)
+                    try h264Params.encode(to: h264ParamsEnc)
+                }
             }
         } else {
             try container.encode(false, forKey: .video)

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -906,15 +906,15 @@ extension SignalingConnect: Codable {
                 }
                 try videoContainer.encodeIfPresent(videoBitRate,
                                                    forKey: .bit_rate)
-                if let vp9Params = vp9Params {
+                if let vp9Params {
                     let vp9ParamsEnc = videoContainer.superEncoder(forKey: .vp9_params)
                     try vp9Params.encode(to: vp9ParamsEnc)
                 }
-                if let av1Params = av1Params {
+                if let av1Params {
                     let av1ParamsEnc = videoContainer.superEncoder(forKey: .av1_params)
                     try av1Params.encode(to: av1ParamsEnc)
                 }
-                if let h264Params = h264Params {
+                if let h264Params {
                     let h264ParamsEnc = videoContainer.superEncoder(forKey: .h264_params)
                     try h264Params.encode(to: h264ParamsEnc)
                 }


### PR DESCRIPTION
`Configuration` に映像コーデックパラメーターの設定を追加しました。
- videoVp9Params
- videoAv1Params
- videoH264Params

以下のように設定が可能です。
```
    var config = Configuration(url: url,
                               channelId: channelId,
                               role: .sendrecv,
                               multistreamEnabled: true)

    // VP9 の場合は profile_id の設定が可能です
    config.videoCodec = .vp9
    config.videoVp9Params = ["profile_id": 0]

    // AV1 の場合は profile の設定が可能です
    config.videoCodec = .av1
    config.videoVp9Params = ["profile": 0]

    // H.264 の場合は profile_level_id の設定が可能です
    config.videoCodec = .h264
    config.videoH264Params = ["profile_level_id": "42e01f"]
```

quickstart の以下ブランチを利用して、テストが可能です。
- SoraQuickStart/ViewController.swift を書き換えながらテストをするイメージです
- Podsfile にはこのブランチを参照する設定がされています
https://github.com/shiguredo/sora-ios-sdk-quickstart/tree/feature/test/add-codec-params