### PR TITLE
WebRTC 115.5790.6.0 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,9 +14,11 @@
 - [UPDATE] システム条件を変更する
     - macOS 13.4.1 以降
     - WebRTC SFU Sora 2023.1.0 以降
+    - Xcode 14.3.1
+    - CocoaPods 1.12.1 以降
     - @miosakuma
-- [UPDATE] WebRTC 114.5735.2.2 に上げる
-    - @szktty
+- [UPDATE] WebRTC 115.5790.6.0 に上げる
+    - @szktty @miosakuma
 - [ADD] 転送フィルター機能を追加する
     - `Configuration` に `forwardingFilter` を追加する
     - @szktty

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let file = "WebRTC-112.5615.1.0/WebRTC.xcframework.zip"
+let file = "WebRTC-115.5790.6.0/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "d4cd24535d4a4122cd8734284f398edeee13a9cff785f8c9522bee3689bbaedf"
+            checksum: "78405439cccb973329e615030cc18dac693102fa3aec245bc29e583673d32b3d"
         ),
         .target(
             name: "Sora",

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '114.5735.2.2'
+  pod 'WebRTC', '115.5790.6.0'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,7 +5,7 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '114.5735.2.2'
+  pod 'WebRTC', '115.5790.6.0'
   pod 'SwiftLint', '0.51.0'
   pod 'SwiftFormat/CLI', '0.51.6'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sora iOS SDK
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-112.5615-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/5615)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-115.5790-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/5790)
 [![GitHub tag](https://img.shields.io/github/tag/shiguredo/sora-ios-sdk.svg)](https://github.com/shiguredo/sora-ios-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
@@ -21,7 +21,7 @@ Please read https://github.com/shiguredo/oss before use.
 - iOS 13 以降
 - アーキテクチャ arm64 (シミュレーターの動作は未保証)
 - macOS 13.4.1 以降
-- Xcode 14.3
+- Xcode 14.3.1
 - Swift 5.8
 - CocoaPods 1.12.1 以降
 - WebRTC SFU Sora 2023.1.0 以降

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '114.5735.2.2'
+  s.dependency "WebRTC", '115.5790.6.0'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -9,16 +9,16 @@ public enum SDKInfo {
  */
 public enum WebRTCInfo {
     /// WebRTC フレームワークのバージョン
-    public static let version = "M112"
+    public static let version = "M115"
 
     /// WebRTC フレームワークのコミットポジション
-    public static let commitPosition = "1"
+    public static let commitPosition = "6"
 
     /// WebRTC フレームワークのメンテナンスバージョン
     public static let maintenanceVersion = "0"
 
     /// WebRTC フレームワークのソースコードのリビジョン
-    public static let revision = "18a31880e3037f9938581c1210d2d73b9685f4aa"
+    public static let revision = "43670de877297a980bfdd1353dd2eb68360e2f2a"
 
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {


### PR DESCRIPTION
sora-ios-sdk-quickstart を利用して CocoaPods, Swift Package Manager を利用したビルドができることを確認しました。
CI 完了後、このままマージします。