### PR TITLE
映像コーデックが指定されていない時に映像コーデックパラメータが送信されない不具合を修正する

### DIFF
--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -897,7 +897,7 @@ extension SignalingConnect: Codable {
         try container.encodeIfPresent(forwardingFilter, forKey: .forwarding_filter)
 
         if videoEnabled {
-            if videoCodec != .default || videoBitRate != nil {
+            if videoCodec != .default || videoBitRate != nil || vp9Params != nil || av1Params != nil || h264Params != nil {
                 var videoContainer = container
                     .nestedContainer(keyedBy: VideoCodingKeys.self,
                                      forKey: .video)


### PR DESCRIPTION
検証中に発覚した不具合について対応しました。
映像コーデック、映像ビットレートが設定されていない場合も映像コーデックパラメータを送信するように修正しています。
映像コーデックなしで映像コーデックパラメータを送信した場合は Sora 側の入力チェックでエラーになりますが、SDK  は設定されたものを過不足なく送る実装にしています。