### PR TITLE
`MediaChannel` の接続数プロパティに値が設定されない不具合を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@
     - すでに廃止済みの `onConnectHandler` が残っていたので、`onConnect` に置き換えた
     - `PeerChannel.swift` と `SignalingChannel.swift` 以外はすでに `onConnect` に置き換えていた
     - @torikizi
+- [FIX] `MediaChannel` の `connectionCount`, `publisherCount`, `subscriberCount` に値が設定されない不具合を修正する
+    - Sora のシグナリングメッセージから channel_upstream_connections, channel_downstream_connections が廃止された契機で値が設定されなくなっていた
+    - Sora のシグナリングメッセージ、channel_sendrecv_connections, channel_sendonly_connections, channel_recvonly_connections, channel_connections を元に値を設定するよう修正
+    - @miosakuma
 
 ## 2023.2.0
 


### PR DESCRIPTION
`MediaChannel` の `connectionCount`, `publisherCount`, `subscriberCount` に値が設定されない不具合を修正しました。

Sora の notify で廃止になっていた `channel_upstream_connections`, `channel_downstream_connections` の値を参照していたので、現在の Sora の仕様に合わせて `channel_sendrecv_connections`, `channel_sendonly_connections`, `channel_recvonly_connections`, `channel_connections` を利用しています。

sora-ios-sdk-quickstart の `ViewController.swift` に以下の修正を入れることで確認ができます。
Sora からシグナリングメッセージを受信するたびにログが出力されます。
connection.created が来るまでは接続数が通知されないため nil が設定されます。

```
@@ -95,6 +96,9 @@ class ViewController: UIViewController {
             }
             strongSelf.updateUI(false)
         }
+        config.mediaChannelHandlers.onReceiveSignaling = { _ in
+            NSLog("mediaChannel count pub/sub/total Count:\(String(describing: self.mediaChannel?.publisherCount)):\(String(describing: self.mediaChannel?.subscriberCount)):\(String(describing: self.mediaChannel?.connectionCount))")
+        }
 
         // 接続します。
         // connect() の戻り値 ConnectionTask を使うと
```