### PR TITLE
AVCaptureDevice.Format の選択時にフレームレートを考慮するように修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,11 +11,11 @@
 
 ## develop
 
+- [UPDATE] CameraVideoCapturer のログを出力する
+  - @enm10k
 - [FIX] AVCaptureDevice.Format の選択時にフレームレートを考慮するように修正する
   - フレームレートに 60 を設定しても、 AVFrameRateRange が 1-30 の AVCaptureDevice.Format が選択されてしまうケースがあった
   - 修正前は、カメラから同じ解像度の AVCaptureDevice.Format が複数取得された場合、最初に解像度が一致した AVCaptureDevice.Format を選択しており、フレームレートが考慮されていないという問題があった
-  - @enm10k
-- [UPDATE] CameraVideoCapturer のログを出力する
   - @enm10k
 
 ## 2023.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - フレームレートに 60 を設定しても、 AVFrameRateRange が 1-30 の AVCaptureDevice.Format が選択されてしまうケースがあった
   - 修正前は、カメラから同じ解像度の AVCaptureDevice.Format が複数取得された場合、最初に解像度が一致した AVCaptureDevice.Format を選択しており、フレームレートが考慮されていないという問題があった
   - @enm10k
+- [UPDATE] CameraVideoCapturer のログを出力する
+  - @enm10k
 
 ## 2023.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+- [FIX] AVCaptureDevice.Format の選択時にフレームレートを考慮するように修正する
+  - フレームレートに 60 を設定しても、 AVFrameRateRange が 1-30 の AVCaptureDevice.Format が選択されてしまうケースがあった
+  - 修正前は、カメラから同じ解像度の AVCaptureDevice.Format が複数取得された場合、最初に解像度が一致した AVCaptureDevice.Format を選択しており、フレームレートが考慮されていないという問題があった
+  - @enm10k
+
 ## 2023.3.0
 
 - [CHANGE] `@available(*, unavailable)` は廃止になるため削除する

--- a/Sora/Logger.swift
+++ b/Sora/Logger.swift
@@ -244,7 +244,8 @@ public final class Logger {
                      .nativePeerChannel,
                      .mediaChannel,
                      .mediaStream,
-                     .dataChannel:
+                     .dataChannel,
+                     .cameraVideoCapturer:
                     out = true
                 default:
                     break

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -466,7 +466,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         // デバイスに対応したフォーマットとフレームレートを取得する
         guard let format = CameraVideoCapturer.format(width: configuration.cameraSettings.resolution.width,
                                                       height: configuration.cameraSettings.resolution.height,
-                                                      for: capturer.device)
+                                                      for: capturer.device,
+                                                      frameRate: configuration.cameraSettings.frameRate)
         else {
             Logger.error(type: .peerChannel, message: "CameraVideoCapturer.suitableFormat failed: suitable format rate is not found")
             return


### PR DESCRIPTION
## 変更内容

カメラのフォーマット選択時のロジックにバグがあったので修正しました。
(詳細は CHANGES.md に記載しています)

## メモ

### 動作確認したい内容

- Configuration.cameraSettings に様々なパターンの解像度、フレームレートを設定する
- カメラの切り替え