### PR TITLE
転送フィルタにバージョンとメタデータを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,13 @@
 - [ADD] VideoCodec に H265 を追加する
   - @enm10k
 - [UPDATE] 解像度に qHD (960x540) を追加する
+  - @enm10k
 - [UPDATE] CocoaPods を v1.14.2 に更新する
   - @enm10k
+- [UPDATE] ForwardingFilter に version と metadata　を追加する
+  - @enm10k @miosakuma
+- [UPDATE] ForwardingFilter の action を未指定にできるようにする
+  - @miosakuma
 
 ## 2023.3.1
 


### PR DESCRIPTION
転送フィルタにバージョンとメタデータを追加する対応をしました。
合わせて action を連携しない確認を行なっています。

動作は確認済みです。追試をする場合は
Configration への設定時に以下のソースを追加することで確認が可能です。

```
        config.forwardingFilter = ForwardingFilter(
            // action: .block,
            rules: [
                [
                    ForwardingFilterRule(field: .kind,
                                         operator: .isIn,
                                         values: ["audio"]),
                ],
            ],
            version: "test",
            metadata: ["spam": "egg", "ham": "bacon"]
        )

```

以下は @enm10k に対応してもらいました。ありがとうございます。

---

うまくいっていないため相談用の PR です。

うまくいっていないこと
---

metadata を connect メッセージの signalingConnectMetadata に合わせて `Encodable?` で定義したい。
その場合は ForwardingFilter は Codable ではなくなるので
以下の SignalingConnect 内で encode ができなくなる。
https://github.com/shiguredo/sora-ios-sdk/blob/develop/Sora/Signaling.swift#L795-L808

どのように定義してどこでエンコードするのがよいかを相談したい。