### PR TITLE
WebRTC 123.6312.3.0 にあげる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] WebRTC m123.6312.3.0 に上げる
+  - @miosakuma
+
 ## 2024.1.0
 
 - [CHANGE] SignalingNotify の metadataList を削除する

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let file = "WebRTC-121.6167.4.0/WebRTC.xcframework.zip"
+let file = "WebRTC-123.6312.3.0/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "096ca45c53b7b77805e6368154462610a8182f61d58a796e69d7b4eb48378f44"
+            checksum: "cb7b9631bac05f2ab9b15772a63bc88529a05192b0f92c3fcb4f28678ea57fe9"
         ),
         .target(
             name: "Sora",

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '121.6167.4.0'
+  pod 'WebRTC', '123.6312.3.0'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,7 +5,7 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '121.6167.4.0'
+  pod 'WebRTC', '123.6312.3.0'
   pod 'SwiftLint', '0.51.0'
   pod 'SwiftFormat/CLI', '0.53.2'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sora iOS SDK
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-121.6167-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6167)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-123.6312-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6312)
 [![GitHub tag](https://img.shields.io/github/tag/shiguredo/sora-ios-sdk.svg)](https://github.com/shiguredo/sora-ios-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '121.6167.4.0'
+  s.dependency "WebRTC", '123.6312.3.0'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -9,16 +9,16 @@ public enum SDKInfo {
  */
 public enum WebRTCInfo {
     /// WebRTC フレームワークのバージョン
-    public static let version = "M121"
+    public static let version = "M123"
 
     /// WebRTC フレームワークのコミットポジション
-    public static let commitPosition = "4"
+    public static let commitPosition = "3"
 
     /// WebRTC フレームワークのメンテナンスバージョン
     public static let maintenanceVersion = "0"
 
     /// WebRTC フレームワークのソースコードのリビジョン
-    public static let revision = "0f741da200c064aea70a790d2fbf678e930bff39"
+    public static let revision = "41b1493ddb5d98e9125d5cb002fd57ce76ebd8a7"
 
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {


### PR DESCRIPTION
libwebrtc のアップデートを行いました。

Swift Package および Cocoa Pods でインストール可能なことを確認済です。

---

This pull request primarily updates the version of WebRTC from `121.6167.4.0` to `123.6312.3.0` across multiple files in the project. The changes include updates to the version number in the `Package.swift`, `Podfile`, `Podfile.dev`, `Sora.podspec`, and `PackageInfo.swift` files, as well as updates to the README and CHANGES documentation files.

Here are the most important changes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Added an update entry for the new WebRTC version `123.6312.3.0`.
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6): Updated the WebRTC file and checksum references to match the new version. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL19-R19)
* `Podfile` and `Podfile.dev`: Updated the WebRTC pod version. [[1]](diffhunk://#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cbL8-R8) [[2]](diffhunk://#diff-3c49ded39aba3ab23c6fa84f595084cdcf5d219729912f355a7eb24895cbfeeaL8-R8)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the WebRTC version badge.
* [`Sora.podspec`](diffhunk://#diff-74da782083bbd46f709bd607809c5d9f9fe4294a93679382cb722d3e22762067L18-R18): Updated the WebRTC dependency version.
* [`Sora/PackageInfo.swift`](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbL12-R21): Updated the WebRTC version, commit position, and revision.