### PR TITLE
libwebrtc のバージョン文字列を Android にあわせる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,14 @@
 
 ## develop
 
+- [CHANGE] シグナリング `connect` メッセージの `libwebrtc` に含まれるバージョン文字列に branch-heads を追加する
+  - 送信される文字列は `Shiguredo-build M123 (M123.3.0 41b1493)` から、`Shiguredo-build M123 (M123.6312.3.0 41b1493)` に変更される
+  - @miosakuma
 - [UPDATE] WebRTC m123.6312.3.0 に上げる
+  - @miosakuma
+- [UPDATE] SDKInfo, WebRTCInfo に versionString を追加し、バージョン文字列はここから取得するようにする
+  - 今まで Configration.swift, PeerChannel.swift などで独自で修正するようにしていたが、これからはバージョン文字列の編集は SDKInfo, WebRTCInfo で行う 
+  - 受け渡しをする文字列の編集バリエーションが増えた時もここで行うようにする
   - @miosakuma
 
 ## 2024.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,10 @@
 
 ## develop
 
-- [CHANGE] シグナリング `connect` メッセージの `libwebrtc` に含まれるバージョン文字列に branch-heads を追加する
-  - 送信される文字列は `Shiguredo-build M123 (M123.3.0 41b1493)` から、`Shiguredo-build M123 (M123.6312.3.0 41b1493)` に変更される
+- [CHANGE] シグナリング `connect` メッセージの `libwebrtc` に含まれるバージョン文字列を Android と揃える
+  - branch-heads を追加する
+  - () 内の libwebrtc バージョンについて最初の 1 文字を削る
+  - 送信される文字列は `Shiguredo-build M123 (M123.3.0 41b1493)` から、`Shiguredo-build M123 (123.6312.3.0 41b1493)` に変更される
   - @miosakuma
 - [UPDATE] WebRTC m123.6312.3.0 に上げる
   - @miosakuma

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -26,7 +26,7 @@ public struct Proxy: CustomStringConvertible {
     let password: String?
 
     /// エージェント
-    var agent: String = "Sora iOS SDK \(SDKInfo.version)"
+    var agent: String = SDKInfo.versionString
 
     /**
      初期化します。

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -28,9 +28,10 @@ public enum WebRTCInfo {
             revision.startIndex, offsetBy: 7
         )])
     }
+
     /// WebRTC の branch-heads
     public static let branchHeads = "6312"
 
-    ///  libwebrtc のバージョン文字列
+    ///  libwebrtc のバージョン文字列 例) "Shiguredo-build M123 (M123.6312.3.0 41b1493)"
     public static let versionString = "Shiguredo-build \(version) (\(version).\(branchHeads).\(commitPosition).\(maintenanceVersion) \(shortRevision))"
 }

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -28,6 +28,9 @@ public enum WebRTCInfo {
             revision.startIndex, offsetBy: 7
         )])
     }
+    /// WebRTC の branch-heads
+    public static let branchHeads = "6312"
+
     ///  libwebrtc のバージョン文字列
-    public static let versionString = "Shiguredo-build \(version) (\(version).\(commitPosition).\(maintenanceVersion) \(shortRevision))"
+    public static let versionString = "Shiguredo-build \(version) (\(version).\(branchHeads).\(commitPosition).\(maintenanceVersion) \(shortRevision))"
 }

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -33,5 +33,5 @@ public enum WebRTCInfo {
     public static let branchHeads = "6312"
 
     ///  libwebrtc のバージョン文字列 例) "Shiguredo-build M123 (M123.6312.3.0 41b1493)"
-    public static let versionString = "Shiguredo-build \(version) (\(version).\(branchHeads).\(commitPosition).\(maintenanceVersion) \(shortRevision))"
+    public static let versionString = "Shiguredo-build \(version) (\(String(version.dropFirst())).\(branchHeads).\(commitPosition).\(maintenanceVersion) \(shortRevision))"
 }

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -1,7 +1,9 @@
 /// :nodoc:
 public enum SDKInfo {
-    // Sora iOS SDK のバージョンを定義する
+    /// Sora iOS SDK のバージョンを定義する
     public static let version = "2024.1.0"
+    /// Sora iOS SDK のバージョン文字列
+    public static let versionString = "Sora iOS SDK \(version)"
 }
 
 /**
@@ -26,4 +28,6 @@ public enum WebRTCInfo {
             revision.startIndex, offsetBy: 7
         )])
     }
+    ///  libwebrtc のバージョン文字列
+    public static let versionString = "Shiguredo-build \(version) (\(version).\(commitPosition).\(maintenanceVersion) \(shortRevision))"
 }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -305,9 +305,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
             multistream = true
         }
 
-        let soraClient = "Sora iOS SDK \(SDKInfo.version)"
+        let soraClient = SDKInfo.versionString
 
-        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
+        let webRTCVersion = WebRTCInfo.versionString
 
         let simulcast = configuration.simulcastEnabled
         let connect = SignalingConnect(


### PR DESCRIPTION
大きく 2 点の修正を行なっています。

1. バージョン文字列を SDKInfo, WebRTCInfo で修正する
2. シグナリング connect で送信される libwebrtc の内容を Android にあわせる

## 1. バージョン文字列を SDKInfo, WebRTCInfo で修正する

これまで Configration.swift, PeerChannel.swift などで SDK バージョン情報や、libwebrtc 情報を編集していましたが、これを SDKInfo, WebRTCInfo で行うように修正しました。バージョン情報は SDKInfo, WebRTCInfo 内で管理した方がよいと考えたためです。

#### コメントあればお願いしたいこと
  - versionString という変数名にしたが違和感はないか？ 

##  2. シグナリング connect で送信される libwebrtc の内容を Android にあわせる
---

当初は branch-head の値が送信されていないことから始まりましたが、
最終的には Android の同項目と出力内容を合わせる対応としています。
Sora C++ SDK も () 内に M がないのでそちらに合わせることにしました。

- branch-head の項目がないので追加しました。
- () 内の文字列から先頭の M を取り除きました

修正前
"libwebrtc": "Shiguredo-build M123 (M123.3.0 41b1493)"

修正後
"libwebrtc": "Shiguredo-build M123 (123.6312.3.0 41b1493)"

Sora Android SDK の出力内容 
"libwebrtc": "Shiguredo-build M121 (121.6167.4.0 0f741da)"

#### コメントあればお願いしたいこと
  - m121 に続く 4 桁の数字は branch-heads (branchHeads) だという認識なのですがもし違っていたらご指摘ください

## 確認した内容

- SDK 情報 (sora_client) について修正前後で変化がないことを確認しました
  - "sora_client": "Sora iOS SDK 2024.1.0"
- libwebrtc 情報について想定通りの出力であることを確認しました
  - "libwebrtc": "Shiguredo-build M123 (123.6312.3.0 41b1493)"
- SDKInfo, WebRTCInfo の利用箇所は一通り確認して修正しています

---
This pull request primarily focuses on improving the versioning system and handling of version strings in the Sora iOS SDK. The changes include adding a branch-heads to the version string in the `connect` message of signaling, updating the WebRTC version, and centralizing the version string editing in `SDKInfo` and `WebRTCInfo`. Additionally, the `agent` in `Configuration.swift` and `soraClient` in `PeerChannel.swift` are now using the updated version strings.

Versioning system improvements:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R22): Added a change log entry for adding branch-heads to the version string in the `connect` message of signaling, updating the WebRTC version, and centralizing the version string editing in `SDKInfo` and `WebRTCInfo`.

Codebase changes:

* [`Sora/Configuration.swift`](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L29-R29): Updated the `agent` string to use `SDKInfo.versionString` instead of concatenating "Sora iOS SDK" with `SDKInfo.version`.
* [`Sora/PackageInfo.swift`](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbL3-R6): Added a `versionString` to `SDKInfo` and `WebRTCInfo` that includes the version and branch-heads. [[1]](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbL3-R6) [[2]](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbR31-R36)
* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L308-R310): Updated `soraClient` and `webRTCVersion` to use the new `versionString` from `SDKInfo` and `WebRTCInfo` respectively.