### PR TITLE
`libwebrtc` に含まれるバージョン文字列を Android と揃える

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [CHANGE] シグナリング `connect` メッセージの `libwebrtc` に含まれるバージョン文字列を Android と揃える
+  - branch-heads を追加する
+  - () 内の libwebrtc バージョンについて最初の 1 文字を削る
+  - 送信される文字列は `Shiguredo-build M122 (M122.1.0 6b419a0)` から、`Shiguredo-build M122 (122.6261.1.0 6b419a0)` に変更される
 - [UPDATE] WebRTC m122.6261.1.0 に上げる
   - @miosakuma
 

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -20,6 +20,9 @@ public enum WebRTCInfo {
     /// WebRTC フレームワークのソースコードのリビジョン
     public static let revision = "6b419a0536b1a0ccfff3682f997c6f19bcbd9bd8"
 
+    /// WebRTC の branch-heads
+    public static let branchHeads = "6261"
+
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {
         String(revision[revision.startIndex ..< revision.index(

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -21,7 +21,7 @@ public enum WebRTCInfo {
     public static let revision = "6b419a0536b1a0ccfff3682f997c6f19bcbd9bd8"
 
     /// WebRTC の branch-heads
-    public static let branchHeads = "6261"
+    public static let branch = "6261"
 
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -307,7 +307,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
         let soraClient = "Sora iOS SDK \(SDKInfo.version)"
 
-        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
+        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(String(WebRTCInfo.version.dropFirst())).\(WebRTCInfo.branchHeads).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
 
         let simulcast = configuration.simulcastEnabled
         let connect = SignalingConnect(

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -307,7 +307,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
         let soraClient = "Sora iOS SDK \(SDKInfo.version)"
 
-        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version.dropFirst()).\(WebRTCInfo.branchHeads).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
+        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version.dropFirst()).\(WebRTCInfo.branch).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
 
         let simulcast = configuration.simulcastEnabled
         let connect = SignalingConnect(

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -307,7 +307,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
         let soraClient = "Sora iOS SDK \(SDKInfo.version)"
 
-        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(String(WebRTCInfo.version.dropFirst())).\(WebRTCInfo.branchHeads).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
+        let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version.dropFirst()).\(WebRTCInfo.branchHeads).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
 
         let simulcast = configuration.simulcastEnabled
         let connect = SignalingConnect(


### PR DESCRIPTION
修正内容
---

シグナリング connect で送信される libwebrtc の内容を Android にあわせました。

当初は branch-head の値が送信されていないことから始まりましたが、
最終的には Android の同項目と出力内容を合わせる対応としています。
Sora C++ SDK も () 内に M をつけていないのでそちらに合わせることにしました。

- branch-head の項目がないので追加しました。
- () 内の文字列から先頭の M を取り除きました

修正前
"libwebrtc":"Shiguredo-build M122 (M122.1.0 6b419a0)"

修正後
"libwebrtc":"Shiguredo-build M122 (122.6261.1.0 6b419a0)"

Sora Android SDK の出力内容 
"libwebrtc": "Shiguredo-build M121 (121.6167.4.0 0f741da)"

## 確認した内容

- libwebrtc 情報について想定通りの出力であることを確認しました
  - "libwebrtc": "Shiguredo-build M123 (123.6312.3.0 41b1493)"

---

This pull request includes changes to the `CHANGES.md`, `Sora/PackageInfo.swift`, and `Sora/PeerChannel.swift` files. The most important changes are aimed at aligning the version string of `libwebrtc` in the `connect` signaling message with Android. This involves adding `branch-heads`, removing the first character of the `libwebrtc` version in parentheses, and modifying the transmitted string.

Here are the key changes:

Version String Alignment:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R17): Updated the change log to reflect the alignment of the `libwebrtc` version string in the `connect` signaling message with Android. This involves adding `branch-heads`, removing the first character from the `libwebrtc` version in parentheses, and changing the transmitted string from `Shiguredo-build M122 (M122.1.0 6b419a0)` to `Shiguredo-build M122 (122.6261.1.0 6b419a0)`.

Code Changes:

* [`Sora/PackageInfo.swift`](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbR23-R25): Added `branch-heads` to the `WebRTCInfo` enum.
* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L310-R310): Modified the `webRTCVersion` string in the `PeerChannel` class to include the new `branch-heads` and to remove the first character from the `libwebrtc` version.