### PR TITLE
Podfile の CocoaPods のソースリポジトリ URL を変更

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,9 @@
 
 - [UPDATE] WebRTC m125.6422.2.5 に上げる
   - @miosakuma
-- [UPDATE] Podfile, Podfile.dev のソースリポジトリを変更する
-  - `https://github.com/CocoaPods/Specs.git` から `https://cdn.cocoapods.org/` に変更される
+- [UPDATE] CocoaPods のソースリポジトリを GitHub から CDN に変更する
+  - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
+  - https://blog.cocoapods.org/CocoaPods-1.8.0-beta/
   - @zztkm
 
 ## 2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 
 - [UPDATE] WebRTC m125.6422.2.5 に上げる
   - @miosakuma
+- [UPDATE] Podfile, Podfile.dev のソースリポジトリを変更する
+  - `https://github.com/CocoaPods/Specs.git` から `https://cdn.cocoapods.org/` に変更される
+  - @zztkm
 
 ## 2024.2.0
 

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
+source 'https://cdn.cocoapods.org/'
 source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
-source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '13.0'
 

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -1,5 +1,5 @@
+source 'https://cdn.cocoapods.org/'
 source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
-source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '13.0'
 


### PR DESCRIPTION
 変更内容

- [UPDATE] CocoaPods のソースリポジトリを GitHub から CDN に変更する
  - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
  - https://blog.cocoapods.org/CocoaPods-1.8.0-beta/

---
This pull request includes changes to the CocoaPods source repository in the `Podfile` and `Podfile.dev` files. The source repository has been updated from GitHub to a Content Delivery Network (CDN). This change is in line with the default setting for CocoaPods 1.8 and onwards. The `CHANGES.md` file has also been updated to reflect this change.

* [`Podfile`](diffhunk://#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cbR1-L2): Changed the CocoaPods source repository from `https://github.com/CocoaPods/Specs.git` to `https://cdn.cocoapods.org/`.
* [`Podfile.dev`](diffhunk://#diff-3c49ded39aba3ab23c6fa84f595084cdcf5d219729912f355a7eb24895cbfeeaR1-L2): Made the same change as in `Podfile` to ensure consistency across the project.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R19): Added an update entry to document the change of the CocoaPods source repository.