### PR TITLE
SignalingConnect の `metadata`, `signaling_notify_metadata` が nil なのに送信データに {} が含まれる問題を修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
   - https://blog.cocoapods.org/CocoaPods-1.8.0-beta/
   - @zztkm
+- [FIX] SignalingConnect の `metadata`, `signaling_notify_metadata` が nil の場合に {} として送信されてしまう問題を修正する
+  - @zztkm
 
 ## 2024.2.0
 

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -814,8 +814,8 @@ extension SignalingConnect: Codable {
             try metadata.encode(to: metadataEnc)
         }
         // この if 分岐をせずに superEncoder を呼び出すと、`"signaling_notify_metadata": {}` が含まれてしまう
-        let notifyEnc = container.superEncoder(forKey: .signaling_notify_metadata)
         if let notifyMetadata {
+            let notifyEnc = container.superEncoder(forKey: .signaling_notify_metadata)
             try notifyMetadata.encode(to: notifyEnc)
         }
         try container.encodeIfPresent(multistreamEnabled,

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -807,13 +807,16 @@ extension SignalingConnect: Codable {
         try container.encodeIfPresent(clientId, forKey: .client_id)
         try container.encodeIfPresent(bundleId, forKey: .bundle_id)
         try container.encodeIfPresent(sdp, forKey: .sdp)
-        // metadata と notifyMetadata は nil でない場合のみエンコードする
-        // この if 分岐をせずに superEncoder を呼び出すと、`"metadata": {}` が含まれてしまう
+
+        // try metadata?.encode(to: metadataEnc) で metadata が nil の時はエンコードが実行されないように実装しても、
+        // container.superEncoder(forKey: .metadata) の呼び出し時点で子要素の準備までしてしまっているので
+        // metadata が nil の場合でも、`"metadata": {}` になってしまう。
+        // これを回避するために metadata が nil でない場合のみ、container.superEncoder(forKey: .metadata) を呼び出して
+        // encode(to:) を実行するような実装にしている。
         if let metadata {
             let metadataEnc = container.superEncoder(forKey: .metadata)
             try metadata.encode(to: metadataEnc)
         }
-        // この if 分岐をせずに superEncoder を呼び出すと、`"signaling_notify_metadata": {}` が含まれてしまう
         if let notifyMetadata {
             let notifyEnc = container.superEncoder(forKey: .signaling_notify_metadata)
             try notifyMetadata.encode(to: notifyEnc)

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -807,10 +807,17 @@ extension SignalingConnect: Codable {
         try container.encodeIfPresent(clientId, forKey: .client_id)
         try container.encodeIfPresent(bundleId, forKey: .bundle_id)
         try container.encodeIfPresent(sdp, forKey: .sdp)
-        let metadataEnc = container.superEncoder(forKey: .metadata)
-        try metadata?.encode(to: metadataEnc)
+        // metadata と notifyMetadata は nil でない場合のみエンコードする
+        // この if 分岐をせずに superEncoder を呼び出すと、`"metadata": {}` が含まれてしまう
+        if let metadata {
+            let metadataEnc = container.superEncoder(forKey: .metadata)
+            try metadata.encode(to: metadataEnc)
+        }
+        // この if 分岐をせずに superEncoder を呼び出すと、`"signaling_notify_metadata": {}` が含まれてしまう
         let notifyEnc = container.superEncoder(forKey: .signaling_notify_metadata)
-        try notifyMetadata?.encode(to: notifyEnc)
+        if let notifyMetadata {
+            try notifyMetadata.encode(to: notifyEnc)
+        }
         try container.encodeIfPresent(multistreamEnabled,
                                       forKey: .multistream)
         try container.encodeIfPresent(soraClient, forKey: .sora_client)


### PR DESCRIPTION
修正内容はこちらです。

- [FIX] SignalingConnect の `metadata`, `signaling_notify_metadata` が nil の場合に {} として送信されてしまう問題を修正する

---
This pull request primarily addresses a bug in the `SignalingConnect` class within `Sora/Signaling.swift`. The bug fix ensures that `metadata` and `signaling_notify_metadata` are only sent if they are not `nil`, preventing the unintended transmission of empty objects `{}`.

Here are the key changes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R20-R21): Added a new entry to document the bug fix in `SignalingConnect` where `metadata` and `signaling_notify_metadata` were being sent as `{}` if they were `nil`. This has now been corrected.

* [`Sora/Signaling.swift`](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R810-R820): Modified the `SignalingConnect` class to only encode `metadata` and `signaling_notify_metadata` if they are not `nil`. This prevents the transmission of empty objects `{}`.