### PR TITLE
simulcast の判定を type: offer の simulcast の値で判定するように修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,12 +17,12 @@
   - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
   - https://blog.cocoapods.org/CocoaPods-1.8.0-beta/
   - @zztkm
-- [ADD] `SignalingOffer` に `simulcast` を追加する
+- [UPDATE] `SignalingOffer` に `simulcast` を追加する
   - @zztkm
 - [FIX] SignalingConnect の `metadata`, `signaling_notify_metadata` が nil の場合に {} として送信されてしまう問題を修正する
   - @zztkm
 - [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする
-  - 認証ウェブフック成功時に払い出された `simulcast` の値を利用する
+  - 認証ウェブフック成功時に払い出された type: offer の `simulcast` の値が反映されない不具合への対応
   - @zztkm
 
 ## 2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - [FIX] SignalingConnect の `metadata`, `signaling_notify_metadata` が nil の場合に {} として送信されてしまう問題を修正する
   - @zztkm
 - [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする
+  - 認証ウェブフック成功時に払い出された `simulcast` の値を利用する
   - @zztkm
 
 ## 2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,11 @@
   - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
   - https://blog.cocoapods.org/CocoaPods-1.8.0-beta/
   - @zztkm
+- [ADD] `SignalingOffer` に `simulcast` を追加する
+  - @zztkm
 - [FIX] SignalingConnect の `metadata`, `signaling_notify_metadata` が nil の場合に {} として送信されてしまう問題を修正する
+  - @zztkm
+- [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする
   - @zztkm
 
 ## 2024.2.0

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -828,7 +828,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
                 signalingOfferMessageDataChannels = dataChannels
             }
 
-            // offer.simaulcast が nil でない場合に WrapperVideoEncoderFactory.shared.simulcastEnabled を上書きする
+            // offer.simulcast が設定されている場合、WrapperVideoEncoderFactory.shared.simulcastEnabled を上書きする
             if let simulcast = offer.simulcast {
                 WrapperVideoEncoderFactory.shared.simulcastEnabled = simulcast
             }

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -828,6 +828,11 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
                 signalingOfferMessageDataChannels = dataChannels
             }
 
+            // offer.simaulcast が nil でない場合に WrapperVideoEncoderFactory.shared.simulcastEnabled を上書きする
+            if let simulcast = offer.simulcast {
+                WrapperVideoEncoderFactory.shared.simulcastEnabled = simulcast
+            }
+
             createAndSendAnswer(offer: offer)
         case let .update(update):
             if configuration.isMultistream {

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -427,6 +427,9 @@ public struct SignalingOffer {
 
     /// mid
     public let mid: [String: String]?
+
+    /// サイマルキャスト有効 / 無効フラグ
+    public let simulcast: Bool?
 }
 
 /**
@@ -958,6 +961,7 @@ extension SignalingOffer: Codable {
         case config
         case encodings
         case mid
+        case simulcast
     }
 
     public init(from decoder: Decoder) throws {
@@ -973,6 +977,7 @@ extension SignalingOffer: Codable {
             try container.decodeIfPresent([Encoding].self,
                                           forKey: .encodings)
         mid = try container.decodeIfPresent([String: String].self, forKey: .mid)
+        simulcast = try container.decodeIfPresent(Bool.self, forKey: .simulcast)
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
変更内容

- [ADD] `SignalingOffer` に `simulcast` を追加する
- [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする
  -  認証ウェブフック成功時に払い出された `simulcast` の値を利用する

---

This pull request primarily focuses on adding support for `simulcast` in the `SignalingOffer` structure and handling it in the `PeerChannel` class. The changes include adding `simulcast` to `SignalingOffer`, decoding it in the `Codable` extension, and updating `WrapperVideoEncoderFactory.shared.simulcastEnabled` based on the `simulcast` value in `PeerChannel`. The `CHANGES.md` file is also updated to reflect these changes.

Here are the key changes:

* `Sora/Signaling.swift`:
  * Added a new optional property `simulcast` of type `Bool?` to `SignalingOffer` structure, which indicates whether simulcast is enabled or not.
  * In the `Codable` extension of `SignalingOffer`, added decoding for `simulcast` from the container. [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R964) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R980)

* `Sora/PeerChannel.swift`:
  * In the `PeerChannel` class, added a check for `offer.simulcast`. If it's not `nil`, `WrapperVideoEncoderFactory.shared.simulcastEnabled` is updated with its value.

* `CHANGES.md`:
  * Added entries about the addition of `simulcast` to `SignalingOffer` and the update of `WrapperVideoEncoderFactory.shared.simulcastEnabled` based on `simulcast` value.