### PR TITLE
WrapperVideoEncoderFactory.shared.simulcastEnabled の設定条件から spotlightEnabled を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@
 - [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする
   - 認証ウェブフック成功時に払い出された type: offer の `simulcast` の値が反映されない不具合への対応
   - @zztkm
+- [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の設定条件から `Configuration.spotlightEnabled` を削除する
+  - `Configuration.spotlightEnabled` はサイマルキャストを有効化するための条件ではないため削除する
+  - @zztkm
 
 ## 2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
   - @zztkm
 - [FIX] `Configuration.spotlightEnabled` はサイマルキャストを有効化するための条件ではないのに、判定条件に加わっていた問題を修正する
   - `WrapperVideoEncoderFactory.shared.simulcastEnabled` の判定条件から `Configuration.spotlightEnabled` を削除する
-  - 本来は、<https://github.com/shiguredo/sora-ios-sdk/commit/44f3b81fd81694f3f670e3de568afc2a6bab5f9f> 時点で修正すべきだったが、漏れていたので修正
+  - <https://github.com/shiguredo/sora-ios-sdk/commit/44f3b81fd81694f3f670e3de568afc2a6bab5f9f> の修正漏れ
   - @zztkm
 
 ## 2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,9 @@
 - [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする
   - 認証ウェブフック成功時に払い出された type: offer の `simulcast` の値が反映されない不具合への対応
   - @zztkm
-- [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の設定条件から `Configuration.spotlightEnabled` を削除する
-  - `Configuration.spotlightEnabled` はサイマルキャストを有効化するための条件ではないため削除する
+- [FIX] `Configuration.spotlightEnabled` はサイマルキャストを有効化するための条件ではないのに、判定条件に加わっていた問題を修正する
+  - `WrapperVideoEncoderFactory.shared.simulcastEnabled` の判定条件から `Configuration.spotlightEnabled` を削除する
+  - 本来は、<https://github.com/shiguredo/sora-ios-sdk/commit/44f3b81fd81694f3f670e3de568afc2a6bab5f9f> 時点で修正すべきだったが、漏れていたので修正
   - @zztkm
 
 ## 2024.2.0

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -195,7 +195,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         lock.lock()
         onConnect = handler
 
-        // TODO (zztkm): WrapperVideoEncoderFactory は type: offer メッセージを受け取ったときに設定されるので、ここでの設定は不要かもしれない
+        // TODO(zztkm): WrapperVideoEncoderFactory は type: offer メッセージを受け取ったときに設定されるので、ここでの設定は不要かもしれない
         // サイマルキャストを利用する場合は、 RTCPeerConnection の生成前に WrapperVideoEncoderFactory を設定する必要がある
         WrapperVideoEncoderFactory.shared.simulcastEnabled = configuration.simulcastEnabled
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -195,9 +195,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         lock.lock()
         onConnect = handler
 
+        // TODO (zztkm): WrapperVideoEncoderFactory は type: offer メッセージを受け取ったときに設定されるので、ここでの設定は不要かもしれない
         // サイマルキャストを利用する場合は、 RTCPeerConnection の生成前に WrapperVideoEncoderFactory を設定する必要がある
-        // また、スポットライトはサイマルキャストを利用しているため、同様に設定が必要になる
-        WrapperVideoEncoderFactory.shared.simulcastEnabled = configuration.simulcastEnabled || configuration.spotlightEnabled == .enabled
+        WrapperVideoEncoderFactory.shared.simulcastEnabled = configuration.simulcastEnabled
 
         signalingChannel.connect { [weak self] error in
             guard let weakSelf = self else {


### PR DESCRIPTION
変更内容

- [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の設定条件から `Configuration.spotlightEnabled` を削除する
  - `Configuration.spotlightEnabled` はサイマルキャストを有効化するための条件ではないため削除する

---

This pull request primarily focuses on fixing and improving the configuration of `simulcastEnabled` in the `WrapperVideoEncoderFactory.shared` instance. The changes include removing the dependency on `Configuration.spotlightEnabled` and ensuring that the `simulcastEnabled` value reflects the value set during the `type: offer` event. 

Here are the key changes:

Changes to `CHANGES.md`:
* Removed the condition that overwrites `WrapperVideoEncoderFactory.shared.simulcastEnabled` with the value of `simulcast` set during the `type: offer` event. This change addresses a bug where the `simulcast` value set during the `type: offer` event was not being reflected.
* Removed `Configuration.spotlightEnabled` from the conditions that set `WrapperVideoEncoderFactory.shared.simulcastEnabled`. This was done because `Configuration.spotlightEnabled` is not a condition for enabling simulcast.

Changes to `Sora/PeerChannel.swift`:
* Removed the setting of `WrapperVideoEncoderFactory.shared.simulcastEnabled` based on `configuration.simulcastEnabled` or `configuration.spotlightEnabled == .enabled`. The new code only sets `simulcastEnabled` based on `configuration.simulcastEnabled`. A comment was added suggesting that the setting of `WrapperVideoEncoderFactory` might not be necessary here because it is set when the `type: offer` message is received.