### PR TITLE
GitHub Actions の定期実行をやめる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
     - 'CHANGES.md'
     - 'LICENSE'
     - 'Sora.podspec'
-  schedule:
-    # UTC の 01:00 は JST だと 10:00 。
-    # 1-5 で 月曜日から金曜日
-    - cron: "0 1 * * 1-5"
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
   - @zztkm
 - [UPDATE] `SignalingOffer` に `simulcast` を追加する
   - @zztkm
+- [UPDATE] GitHub Actions の定期実行をやめる
+  - build.yml の起動イベントから schedule を削除
+  - @zztkm
 - [FIX] SignalingConnect の `metadata`, `signaling_notify_metadata` が nil の場合に {} として送信されてしまう問題を修正する
   - @zztkm
 - [FIX] `WrapperVideoEncoderFactory.shared.simulcastEnabled` の値を type: offer の際に設定される simulcast の値で上書きする


### PR DESCRIPTION
変更内容

- [UPDATE] GitHub Actions の定期実行をやめる
  - build.yml の起動イベントから schedule を削除

---

This pull request primarily involves changes related to the scheduling and documentation of GitHub Actions. The most significant changes include the removal of the scheduled trigger for GitHub Actions and the corresponding update in the `CHANGES.md` file.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-L14): The scheduled trigger for GitHub Actions has been removed. This means that the workflow will no longer run at a specific time on certain days.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R22-R24): The file has been updated to reflect the removal of the scheduled trigger for GitHub Actions. This provides documentation for the change.