### PR TITLE
2025 年 6 月リリースでレガシー ストリーム機能が削除される予定のため、multistreamEnabled を非推奨にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
   - @zztkm
 - [UPDATE] `SignalingOffer` に `simulcast` を追加する
   - @zztkm
+- [UPDATE] multistreamEnabled を非推奨にする
+  - Sora のレガシーストリーム機能が 2025 年 6 月リリースにて廃止されるため
+  - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる
   - build.yml の起動イベントから schedule を削除
   - @zztkm

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -86,6 +86,7 @@ public struct Configuration {
     public var role: Role
 
     /// マルチストリームの可否
+    @available(*, deprecated, message: "レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。")
     public var multistreamEnabled: Bool
 
     /// :nodoc:

--- a/Sora/MediaChannelConfiguration.swift
+++ b/Sora/MediaChannelConfiguration.swift
@@ -1,10 +1,12 @@
 import Foundation
 
+// TODO(zztkm): MediaChannelConfiguration は現在利用されていないため、不要かもしれない
 public class MediaChannelConfiguration {
     public static var maxBitRate = 5000
 
     public var connectionMetadata: String?
     public var connectionTimeout: Int = 30
+    @available(*, deprecated, message: "レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。")
     public var multistreamEnabled: Bool = false
     public var videoCodec: VideoCodec = .default
     public var audioCodec: AudioCodec = .default

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -270,6 +270,7 @@ public struct SignalingConnect {
     public var sdp: String?
 
     /// マルチストリームの可否
+    @available(*, deprecated, message: "レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。")
     public var multistreamEnabled: Bool?
 
     /// 映像の可否


### PR DESCRIPTION
変更内容

- [UPDATE] multistreamEnabled を非推奨にする
  - Sora のレガシーストリーム機能が 2025 年 6 月リリースにて廃止されるため

---

This pull request includes several changes to deprecate the `multistreamEnabled` feature due to the upcoming removal of Sora's legacy stream functionality in June 2025. It also contains a minor update to the `CHANGES.md` file and a TODO comment in `MediaChannelConfiguration.swift`.

Deprecation of `multistreamEnabled`:

* [`Sora/Configuration.swift`](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958R89): Marked `multistreamEnabled` as deprecated with a message indicating the removal of the legacy stream feature in June 2025.
* [`Sora/MediaChannelConfiguration.swift`](diffhunk://#diff-f56c54daae222fc0971825c1cb17cd600b02c80b295e87b43630cfca1978a21aR3-R9): Added a deprecation message to `multistreamEnabled` and included a TODO comment noting that `MediaChannelConfiguration` might be unnecessary.
* [`Sora/Signaling.swift`](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R273): Marked `multistreamEnabled` as deprecated with a message about the upcoming removal of the legacy stream feature.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R22-R24): Added an entry to deprecate `multistreamEnabled` due to the planned removal of Sora's legacy stream functionality.