### PR TITLE
WebRTC m127.6533.1.1 にあげる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@
 
 ## develop
 
-- [UPDATE] WebRTC m125.6422.2.5 に上げる
+- [UPDATE] WebRTC m127.6533.1.1 に上げる
   - @miosakuma
+  - @zztkm
 - [UPDATE] CocoaPods のソースリポジトリを GitHub から CDN に変更する
   - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
   - https://blog.cocoapods.org/CocoaPods-1.8.0-beta/

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let file = "WebRTC-125.6422.2.5/WebRTC.xcframework.zip"
+let file = "WebRTC-127.6533.1.1/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "5f3b36455b72b1448800c38aae5435b973f1ad18169b9ce004e8f7eaee246be4"
+            checksum: "b9242358b4d53cafdf19d75a731cea87c84205475f54816e3a5cfd99cdb03216"
         ),
         .target(
             name: "Sora",

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '125.6422.2.5'
+  pod 'WebRTC', '127.6533.1.1'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,7 +5,7 @@ platform :ios, '13.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '125.6422.2.5'
+  pod 'WebRTC', '127.6533.1.1'
   pod 'SwiftLint', '0.51.0'
   pod 'SwiftFormat/CLI', '0.53.2'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sora iOS SDK
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-125.6422-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6422)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-127.6533-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6533)
 [![GitHub tag](https://img.shields.io/github/tag/shiguredo/sora-ios-sdk.svg)](https://github.com/shiguredo/sora-ios-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '125.6422.2.5'
+  s.dependency "WebRTC", '127.6533.1.1'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -9,19 +9,19 @@ public enum SDKInfo {
  */
 public enum WebRTCInfo {
     /// WebRTC フレームワークのバージョン
-    public static let version = "M125"
+    public static let version = "M127"
 
     /// WebRTC フレームワークのコミットポジション
-    public static let commitPosition = "2"
+    public static let commitPosition = "1"
 
     /// WebRTC フレームワークのメンテナンスバージョン
-    public static let maintenanceVersion = "5"
+    public static let maintenanceVersion = "1"
 
     /// WebRTC フレームワークのソースコードのリビジョン
-    public static let revision = "8505a9838ea91c66c96c173d30cd66f9dbcc7548"
+    public static let revision = "e0b28a6a81a989c1f5c89e30fcd247870047390d"
 
     /// WebRTC の branch-heads
-    public static let branch = "6422"
+    public static let branch = "6433"
 
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {


### PR DESCRIPTION
変更内容

- [UPDATE] WebRTC m127.6533.1.1 に上げる

---
This pull request updates the WebRTC framework version throughout the project from `125.6422.2.5` to `127.6533.1.1`. The changes include updates to various configuration files and documentation to reflect the new version.

### WebRTC Version Update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R16): Updated the WebRTC version to `m127.6533.1.1` and added a new contributor.
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6): Changed the WebRTC file path and checksum to match the new version. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL19-R19)
* [`Podfile`](diffhunk://#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cbL8-R8): Updated the WebRTC pod version to `127.6533.1.1`.
* [`Podfile.dev`](diffhunk://#diff-3c49ded39aba3ab23c6fa84f595084cdcf5d219729912f355a7eb24895cbfeeaL8-R8): Updated the WebRTC pod version to `127.6533.1.1`.
* [`Sora.podspec`](diffhunk://#diff-74da782083bbd46f709bd607809c5d9f9fe4294a93679382cb722d3e22762067L18-R18): Changed the WebRTC dependency version to `127.6533.1.1`.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the WebRTC version badge to `127.6533`.

### Code Update:

* [`Sora/PackageInfo.swift`](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbL12-R24): Updated the WebRTC version, commit position, maintenance version, revision, and branch to reflect the new version.