### PR TITLE
MediaChannelConfiguration クラスを非推奨にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] MediaChannelConfiguration を非推奨にする
+  - SDK 内部では利用していないため
+  - @zztkm
 - [UPDATE] WebRTC m127.6533.1.1 に上げる
   - @miosakuma
   - @zztkm

--- a/Sora/MediaChannelConfiguration.swift
+++ b/Sora/MediaChannelConfiguration.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, unavailable, message: "このクラスは廃止予定です。廃止後も利用したい場合はこのクラス定義をご自身のソースに組み込んで利用してください。")
 public class MediaChannelConfiguration {
     public static var maxBitRate = 5000
 


### PR DESCRIPTION
変更内容

- [CHANGE] MediaChannelConfiguration を非推奨にする
  - SDK 内部では利用していないため

---

This pull request includes a few changes to deprecate the `MediaChannelConfiguration` class and update the WebRTC version.

### Deprecation of `MediaChannelConfiguration`:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Marked `MediaChannelConfiguration` as deprecated because it is no longer used internally.
* [`Sora/MediaChannelConfiguration.swift`](diffhunk://#diff-f56c54daae222fc0971825c1cb17cd600b02c80b295e87b43630cfca1978a21aR3): Added an `@available` attribute to indicate that `MediaChannelConfiguration` is deprecated and provided a message suggesting users incorporate the class definition into their own source if they still want to use it.

### WebRTC Version Update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Updated the WebRTC version to m127.6533.1.1.