### PR TITLE
ICEServerInfo の urls の型を [URL] から [String] に変更

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@
   - `WrapperVideoEncoderFactory.shared.simulcastEnabled` の判定条件から `Configuration.spotlightEnabled` を削除する
   - <https://github.com/shiguredo/sora-ios-sdk/commit/44f3b81fd81694f3f670e3de568afc2a6bab5f9f> の修正漏れ
   - @zztkm
+- [FIX] URL 構造体が TURN URI に対応していないのに、URL に変換していたのを修正する
+  - 意図しないエスケープが発生しないようにした
+  - @zztkm
 
 ## 2024.2.0
 

--- a/Sora/ICEServerInfo.swift
+++ b/Sora/ICEServerInfo.swift
@@ -9,8 +9,7 @@ public final class ICEServerInfo {
 
     /// URL のリスト
     ///
-    /// URL 構造体を使うと、IPv6 がパーセントエンコードされてしまい、
-    /// 接続に失敗してしまうため、String で保持します。
+    /// TURN URI はそのまま文字列として処理する
     public var urls: [String] = []
 
     /// ユーザー名
@@ -64,6 +63,9 @@ extension ICEServerInfo: Codable {
     public convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let urls = try container.decode([String].self, forKey: .urls)
+        for url in urls {
+            Logger.debug(type: .signalingChannel, message: "kensaku: ICEServerInfo: \(url)")
+        }
         let userName = try container.decodeIfPresent(String.self, forKey: .userName)
         let credential = try container.decodeIfPresent(String.self, forKey: .credential)
         self.init(urls: urls,

--- a/Sora/ICEServerInfo.swift
+++ b/Sora/ICEServerInfo.swift
@@ -8,7 +8,10 @@ public final class ICEServerInfo {
     // MARK: プロパティ
 
     /// URL のリスト
-    public var urls: [URL] = []
+    ///
+    /// URL 構造体を使うと、IPv6 がパーセントエンコードされてしまい、
+    /// 接続に失敗してしまうため、String で保持します。
+    public var urls: [String] = []
 
     /// ユーザー名
     public var userName: String?
@@ -20,7 +23,7 @@ public final class ICEServerInfo {
     public var tlsSecurityPolicy: TLSSecurityPolicy = .secure
 
     var nativeValue: RTCIceServer {
-        RTCIceServer(urlStrings: urls.map { url in url.absoluteString },
+        RTCIceServer(urlStrings: urls,
                      username: userName,
                      credential: credential,
                      tlsCertPolicy: tlsSecurityPolicy.nativeValue)
@@ -29,7 +32,7 @@ public final class ICEServerInfo {
     // MARK: 初期化
 
     /// 初期化します。
-    public init(urls: [URL],
+    public init(urls: [String],
                 userName: String?,
                 credential: String?,
                 tlsSecurityPolicy: TLSSecurityPolicy)
@@ -60,7 +63,7 @@ extension ICEServerInfo: Codable {
 
     public convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let urls = try container.decode([URL].self, forKey: .urls)
+        let urls = try container.decode([String].self, forKey: .urls)
         let userName = try container.decodeIfPresent(String.self, forKey: .userName)
         let credential = try container.decodeIfPresent(String.self, forKey: .credential)
         self.init(urls: urls,


### PR DESCRIPTION
変更内容

- [FIX] URL 構造体が TURN URI に対応していないのに、URL に変換していたのを修正する
  - 意図しないエスケープが発生しないようにした

---

This pull request includes changes to the `Sora/ICEServerInfo.swift` file to handle TURN URIs as strings instead of URLs, and a related fix in the `CHANGES.md` file. The most important changes are summarized below:

### Handling TURN URIs as Strings

* [`Sora/ICEServerInfo.swift`](diffhunk://#diff-2d9f4db0b0946f750926ec9296616ace24179c3875b92c60386e17c89b8d59a9L11-R13): Changed the `urls` property from `[URL]` to `[String]` to handle TURN URIs as raw strings.
* [`Sora/ICEServerInfo.swift`](diffhunk://#diff-2d9f4db0b0946f750926ec9296616ace24179c3875b92c60386e17c89b8d59a9L23-R25): Updated the `RTCIceServer` initialization to use the `urls` array directly without converting to `absoluteString`.
* [`Sora/ICEServerInfo.swift`](diffhunk://#diff-2d9f4db0b0946f750926ec9296616ace24179c3875b92c60386e17c89b8d59a9L32-R34): Modified the initializer to accept `urls` as `[String]` instead of `[URL]`.
* [`Sora/ICEServerInfo.swift`](diffhunk://#diff-2d9f4db0b0946f750926ec9296616ace24179c3875b92c60386e17c89b8d59a9L63-R68): Adjusted the `Codable` conformance to decode `urls` as `[String]` and added debug logging for each URL.

### Documentation Update

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R38-R40): Added a fix entry for handling TURN URIs correctly to prevent unintended escaping.