### PR TITLE
Github Actions の Xcode を 15.4 にあげる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@
 - [UPDATE] GitHub Actions の定期実行をやめる
   - build.yml の起動イベントから schedule を削除
   - @zztkm
+- [UPDATE] GitHub Actions の Xcode のバージョンを 15.4 にあげる
+  - 合わせて iOS の SDK を iphoneos17.5 にあげる
+  - @miosakuma
 - [UPDATE] CocoaPods のソースリポジトリを GitHub から CDN に変更する
   - CocoaPods 1.8 からソースリポジトリのデフォルトが `https://cdn.cocoapods.org/` になった
   - <https://blog.cocoapods.org/CocoaPods-1.8.0-beta/>


### PR DESCRIPTION
- [UPDATE] GitHub Actions の Xcode のバージョンを 15.4 にあげる
  - 合わせて iOS の SDK を iphoneos17.5 にあげる

---

This pull request includes updates to the GitHub Actions workflow and documentation to reflect changes in the Xcode version and iOS SDK used for builds.

### GitHub Actions Workflow Update:

* Updated the Xcode version to 15.4 and the iOS SDK to iphoneos17.5 in the GitHub Actions workflow configuration file `.github/workflows/build.yml`. (`XCODE` and `XCODE_SDK` environment variables)

### Documentation Update:

* Added a note in `CHANGES.md` to document the update of Xcode to version 15.4 and the iOS SDK to iphoneos17.5.