### PR TITLE
forwardig_filters に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,9 @@
   - libwebrtc の対象バージョンに追従した
     - <https://webrtc.googlesource.com/src/+/9b81d2c954128831c62d8a0657c7f955b3c02d32>
   - @miosakuma
-- [UPDATE] `ForwardingFilter` に name と priority を追加する
+- [ADD] `ForwardingFilter` に name と priority を追加する
   - @zztkm
-- [UPDATE] シグナリング connect 時にリスト形式の転送フィルターを設定するための項目を追加する
+- [ADD] シグナリング connect 時にリスト形式の転送フィルターを設定するための項目を追加する
   - `Configuration`, `SignalingConnect` に forwardingFilters を追加する
   - @zztkm
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@
   - libwebrtc の対象バージョンに追従した
     - <https://webrtc.googlesource.com/src/+/9b81d2c954128831c62d8a0657c7f955b3c02d32>
   - @miosakuma
+- [UPDATE] `ForwardingFilter` に name と priority を追加する
+  - @zztkm
+- [UPDATE] シグナリング connect 時にリスト形式の転送フィルターを設定するための項目を追加する
+  - `Configuration`, `SignalingConnect` に forwardingFilters を追加する
+  - @zztkm
 
 ### misc
 

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -182,6 +182,8 @@ public struct Configuration {
     public var proxy: Proxy?
 
     /// 転送フィルターの設定
+    ///
+    /// この項目は 2025 年 12 月リリース予定の Sora にて廃止されます
     public var forwardingFilter: ForwardingFilter?
 
     /// リスト形式の転送フィルターの設定

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -183,7 +183,7 @@ public struct Configuration {
 
     /// 転送フィルターの設定
     public var forwardingFilter: ForwardingFilter?
-    
+
     /// リスト形式の転送フィルターの設定
     public var forwardingFilters: [ForwardingFilter]?
 

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -183,6 +183,9 @@ public struct Configuration {
 
     /// 転送フィルターの設定
     public var forwardingFilter: ForwardingFilter?
+    
+    /// リスト形式の転送フィルターの設定
+    public var forwardingFilters: [ForwardingFilter]?
 
     /// VP9 向け映像コーデックパラメーター
     public var videoVp9Params: Encodable?
@@ -323,6 +326,12 @@ public enum ForwardingFilterAction: String, Encodable {
  転送フィルターに関する設定です。
  */
 public struct ForwardingFilter {
+    /// name
+    public var name: String?
+
+    /// priority
+    public var priority: Int?
+
     /// action
     public var action: ForwardingFilterAction?
 
@@ -343,7 +352,9 @@ public struct ForwardingFilter {
      - parameter version: version (オプショナル)
      - parameter metadata: metadata (オプショナル)
      */
-    public init(action: ForwardingFilterAction? = nil, rules: [[ForwardingFilterRule]], version: String? = nil, metadata: Encodable? = nil) {
+    public init(name: String? = nil, priority: Int? = nil, action: ForwardingFilterAction? = nil, rules: [[ForwardingFilterRule]], version: String? = nil, metadata: Encodable? = nil) {
+        self.name = name
+        self.priority = priority
         self.action = action
         self.rules = rules
         self.version = version
@@ -353,6 +364,8 @@ public struct ForwardingFilter {
 
 extension ForwardingFilter: Encodable {
     enum CodingKeys: String, CodingKey {
+        case name
+        case priority
         case action
         case rules
         case version
@@ -361,6 +374,8 @@ extension ForwardingFilter: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(priority, forKey: .priority)
         try container.encodeIfPresent(action, forKey: .action)
         try container.encode(rules, forKey: .rules)
         try container.encodeIfPresent(version, forKey: .version)

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -641,7 +641,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
     private func updateSenderOfferEncodings() {
         guard let nativeChannel else {
-            Logger.debug(type: .peerChannel, message: "nativeChannel shoud not be nil")
+            Logger.debug(type: .peerChannel, message: "nativeChannel should not be nil")
             return
         }
 
@@ -657,7 +657,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
     private func createAndSendAnswer(offer: SignalingOffer) {
         guard let nativeChannel else {
-            Logger.debug(type: .peerChannel, message: "nativeChannel shoud not be nil")
+            Logger.debug(type: .peerChannel, message: "nativeChannel should not be nil")
             return
         }
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -339,6 +339,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
             audioStreamingLanguageCode: configuration.audioStreamingLanguageCode,
             redirect: redirect,
             forwardingFilter: configuration.forwardingFilter,
+            forwardingFilters: configuration.forwardingFilters,
             vp9Params: configuration.videoVp9Params,
             av1Params: configuration.videoAv1Params,
             h264Params: configuration.videoH264Params

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -331,6 +331,9 @@ public struct SignalingConnect {
 
     /// 転送フィルターの設定
     public var forwardingFilter: ForwardingFilter?
+    
+    /// リスト形式の転送フィルターの設定
+    public var forwardingFilters: [ForwardingFilter]?
 
     /// VP9 向け映像コーデックパラメーター
     public var vp9Params: Encodable?
@@ -784,6 +787,7 @@ extension SignalingConnect: Codable {
         case audio_streaming_language_code
         case redirect
         case forwarding_filter
+        case forwarding_filters
     }
 
     enum VideoCodingKeys: String, CodingKey {
@@ -834,6 +838,7 @@ extension SignalingConnect: Codable {
         try container.encodeIfPresent(audioStreamingLanguageCode, forKey: .audio_streaming_language_code)
         try container.encodeIfPresent(redirect, forKey: .redirect)
         try container.encodeIfPresent(forwardingFilter, forKey: .forwarding_filter)
+        try container.encodeIfPresent(forwardingFilters, forKey: .forwarding_filters)
 
         if videoEnabled {
             if videoCodec != .default || videoBitRate != nil || vp9Params != nil || av1Params != nil || h264Params != nil {

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -330,6 +330,8 @@ public struct SignalingConnect {
     public var redirect: Bool?
 
     /// 転送フィルターの設定
+    ///
+    /// この項目は 2025 年 12 月リリース予定の Sora にて廃止されます
     public var forwardingFilter: ForwardingFilter?
 
     /// リスト形式の転送フィルターの設定

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -331,7 +331,7 @@ public struct SignalingConnect {
 
     /// 転送フィルターの設定
     public var forwardingFilter: ForwardingFilter?
-    
+
     /// リスト形式の転送フィルターの設定
     public var forwardingFilters: [ForwardingFilter]?
 


### PR DESCRIPTION
- [UPDATE] `ForwardingFilter` に name と priority を追加する
- [UPDATE] シグナリング connect 時にリスト形式の転送フィルターを設定するための項目を追加する
  - `Configuration`, `SignalingConnect` に forwardingFilters を追加する

---

This pull request introduces enhancements to the forwarding filter functionality and includes some minor corrections. The most significant changes involve adding support for list-based forwarding filters and refining the `ForwardingFilter` structure.

Enhancements to forwarding filter functionality:

* [`Sora/Configuration.swift`](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958R187-R189): Added `forwardingFilters` property to `Configuration` struct and updated the `ForwardingFilter` struct to include `name` and `priority` properties. [[1]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958R187-R189) [[2]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958R329-R334) [[3]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L346-R357) [[4]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958R367-R368) [[5]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958R377-R378)
* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457R342): Modified `PeerChannel` class to handle the new `forwardingFilters` property in its configuration.
* [`Sora/Signaling.swift`](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R335-R337): Updated `SignalingConnect` struct to include the `forwardingFilters` property and ensured it is encoded properly. [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R335-R337) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R790) [[3]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R841)

Minor corrections:

* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L644-R645): Corrected a typo in debug messages from "shoud" to "should". [[1]](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L644-R645) [[2]](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L660-R661)
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R23-R27): Documented the updates to `ForwardingFilter` and the addition of list-based forwarding filters.