### PR TITLE
シグナリング notify の項目を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,14 @@
     - `video`
     - `videoCodecType`
     - `videoBitRate`
+- [ADD] SignalingNotify に項目を追加する
+  - 追加する項目
+    - `timestamp`
+    - `spotlightNumber`
+    - `failedConnectionId`
+    - `currentState`
+    - `previousState`
+  - @zztkm
 
 ### misc
 

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -633,13 +633,13 @@ public struct SignalingNotify {
     public var streamId: String?
 
     /// 音声ストリーミング処理に失敗したコネクション ID
-    var failedConnectionId: String?
+    public var failedConnectionId: String?
 
     /// ICE コネクションステートの現在の状態
-    var currentState: String?
+    public var currentState: String?
 
     /// ICE コネクションステートの遷移前の状態
-    var previousState: String?
+    public var previousState: String?
 }
 
 /**

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -544,6 +544,9 @@ public struct SignalingNotify {
     /// イベントの種別
     public var eventType: String
 
+    /// タイムスタンプ
+    public var timestamp: String?
+
     // MARK: 接続情報
 
     /// ロール
@@ -560,6 +563,9 @@ public struct SignalingNotify {
 
     /// 接続 ID
     public var connectionId: String?
+
+    /// スポットライトでフォーカスされる配信数
+    public var spotlightNumber: Int?
 
     /// 音声の可否
     public var audioEnabled: Bool?
@@ -625,6 +631,15 @@ public struct SignalingNotify {
 
     /// 再開された RTP ストリームの送信元接続 ID
     public var streamId: String?
+
+    /// 音声ストリーミング処理に失敗したコネクション ID
+    var failedConnectionId: String?
+
+    /// ICE コネクションステートの現在の状態
+    var currentState: String?
+
+    /// ICE コネクションステートの遷移前の状態
+    var previousState: String?
 }
 
 /**
@@ -1144,11 +1159,13 @@ extension SignalingPush: Codable {
 extension SignalingNotify: Codable {
     enum CodingKeys: String, CodingKey {
         case event_type
+        case timestamp
         case role
         case session_id
         case client_id
         case bundle_id
         case connection_id
+        case spotlight_number
         case audio
         case video
         case minutes
@@ -1168,18 +1185,25 @@ extension SignalingNotify: Codable {
         case recv_connection_id
         case send_connection_id
         case stream_id
+        case failed_connection_id
+        case current_state
+        case previous_state
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         eventType = try container.decode(String.self,
                                          forKey: .event_type)
+        timestamp = try container.decodeIfPresent(String.self,
+                                                  forKey: .timestamp)
         role = try container.decodeIfPresent(SignalingRole.self, forKey: .role)
         sessionId = try container.decodeIfPresent(String.self, forKey: .session_id)
         clientId = try container.decodeIfPresent(String.self, forKey: .client_id)
         bundleId = try container.decodeIfPresent(String.self, forKey: .bundle_id)
         connectionId = try container.decodeIfPresent(String.self,
                                                      forKey: .connection_id)
+        spotlightNumber = try container.decodeIfPresent(Int.self,
+                                                        forKey: .spotlight_number)
         audioEnabled = try container.decodeIfPresent(Bool.self, forKey: .audio)
         videoEnabled = try container.decodeIfPresent(Bool.self, forKey: .video)
         connectionTime = try container.decodeIfPresent(Int.self, forKey: .minutes)
@@ -1211,6 +1235,10 @@ extension SignalingNotify: Codable {
             try container.decodeIfPresent(String.self, forKey: .send_connection_id)
         streamId =
             try container.decodeIfPresent(String.self, forKey: .stream_id)
+        failedConnectionId =
+            try container.decodeIfPresent(String.self, forKey: .failed_connection_id)
+        currentState = try container.decodeIfPresent(String.self, forKey: .current_state)
+        previousState = try container.decodeIfPresent(String.self, forKey: .previous_state)
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
- [ADD] SignalingNotify に項目を追加する
  - 追加する項目
    - `timestamp`
    - `spotlightNumber`
    - `failedConnectionId`
    - `currentState`
    - `previousState`

---

This pull request includes changes to the `SignalingNotify` struct in the `Sora/Signaling.swift` file to add new properties and update the `Codable` conformance. Additionally, the `CHANGES.md` file has been updated to reflect these changes.

Changes to `SignalingNotify` struct:

* Added new properties: `timestamp`, `spotlightNumber`, `failedConnectionId`, `currentState`, and `previousState`. [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R547-R549) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R567-R569) [[3]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R634-R642)
* Updated `Codable` conformance to include the new properties in the `CodingKeys` enum and the `init(from decoder: Decoder)` method. [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R1162-R1168) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R1188-R1206) [[3]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R1238-R1241)

Documentation update:

* Updated `CHANGES.md` to include the new properties added to `SignalingNotify`.