### PR TITLE
GitHub Actions 環境をアップデート

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode Version
@@ -76,7 +76,7 @@ jobs:
           SLACK_COLOR: danger
           SLACK_TITLE: "FAILED"
           SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}  
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   release:
     if: contains(github.ref, 'tags/v')
     needs: [build]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,11 @@
   - macOS の条件を外す
     - Xcode とほぼ同時更新なので一旦不要と判断
   - @miosakuma
+- [UPDATE] GitHub Actions のビルド環境を更新する
+  - runner を macos-15 に変更
+  - Xcode の version を 16.2 に変更
+  - SDK を iOS 18.2 に変更
+  - @zztkm
 
 ## 2024.3.0
 


### PR DESCRIPTION
- [UPDATE] GitHub Actions のビルド環境を更新する
  - runner を macos-15 に変更
  - Xcode の version を 16.2 に変更
  - SDK を iOS 18.2 に変更

---

This pull request updates the GitHub Actions build environment to use the latest macOS and Xcode versions.

Updates to GitHub Actions build environment:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L14-R17): Changed the runner to `macos-15`, updated `XCODE` to version `16.2`, and updated `XCODE_SDK` to `iphoneos18.2`.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R60-R64): Documented the updates to the GitHub Actions build environment, including the runner change to `macos-15`, Xcode version change to `16.2`, and SDK change to `iOS 18.2`.