### PR TITLE
jazzy 設定の `xcodebuild_arguments` の iphoneos を 18.2 に変更する

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -13,7 +13,7 @@ swift_version: 5.10.0
 xcodebuild_arguments:
     - -parallelizeTargets
     - -sdk
-    - iphoneos17.5
+    - iphoneos18.2
     - -workspace
     - Sora.xcworkspace
     - -scheme

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -9,7 +9,7 @@ min_acl: public
 sdk: iphoneos
 module: Sora
 module_version: 2024.3.0
-swift_version: 5.10.0
+swift_version: 6.0.3
 xcodebuild_arguments:
     - -parallelizeTargets
     - -sdk

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@
   - Xcode の version を 16.2 に変更
   - SDK を iOS 18.2 に変更
   - @zztkm
+- [UPDATE] jazzy 設定の `xcodebuild_arguments` の iphoneos を 18.2 に変更する
+  - @zztkm
 
 ## 2024.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,7 +62,9 @@
   - Xcode の version を 16.2 に変更
   - SDK を iOS 18.2 に変更
   - @zztkm
-- [UPDATE] jazzy 設定の `xcodebuild_arguments` の iphoneos を 18.2 に変更する
+- [UPDATE] jazzy の設定ファイルを更新する
+  - `swift_version` を 6.0.3 に変更
+  - `xcodebuild_arguments` の iphoneos を 18.2 に変更
   - @zztkm
 
 ## 2024.3.0


### PR DESCRIPTION
- [UPDATE] jazzy の設定ファイルを更新する
  - `swift_version` を 6.0.3 に変更
  - `xcodebuild_arguments` の iphoneos を 18.2 に変更

---

This pull request includes updates to the jazzy configuration and the CHANGES.md file to reflect the latest versions of Swift and iOS SDK.

Configuration updates:

* [`.jazzy.yaml`](diffhunk://#diff-b3ad788db372a018ab1a7a55ab77c196cae70a9a83dc095ee25b5ac0594187ffL12-R16): Updated `swift_version` to 6.0.3 and `xcodebuild_arguments` to use `iphoneos18.2`.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R65-R68): Added an entry to document the updates made to the jazzy configuration file, including changes to `swift_version` and `xcodebuild_arguments`.