### PR TITLE
libwebrtc を 132.6834.5.1 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 
 ## develop
 
-- [UPDATE] WebRTC m129.6668.1.0 に上げる
-  - @miosakuma
+- [UPDATE] WebRTC m132.6834.5.1 に上げる
+  - @miosakuma @zztkm
 - [UPDATE] システム条件の iOS を 14.0 に上げる
   - IPHONEOS_DEPLOYMENT_TARGET を 14.0 に上げる
   - SwiftPM の platforms の設定を v14 に上げる

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let file = "WebRTC-129.6668.1.0/WebRTC.xcframework.zip"
+let file = "WebRTC-132.6834.5.1/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "c23dc224a8edd61410c089696dc34c03c81712672b0e419df627d4e1fc15bafc"
+            checksum: "aebb5da7acc657c3307394d114df4a4b69e747554f12af302bcdd2cd0c0b0d20"
         ),
         .target(
             name: "Sora",

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '14.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '129.6668.1.0'
+  pod 'WebRTC', '132.6834.5.1'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,7 +5,7 @@ platform :ios, '14.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '129.6668.1.0'
+  pod 'WebRTC', '132.6834.5.1'
   pod 'SwiftLint', '0.51.0'
   pod 'SwiftFormat/CLI', '0.53.2'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sora iOS SDK
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-129.6668-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6668)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-132.6834-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/6834)
 [![GitHub tag](https://img.shields.io/github/tag/shiguredo/sora-ios-sdk.svg)](https://github.com/shiguredo/sora-ios-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '129.6668.1.0'
+  s.dependency "WebRTC", '132.6834.5.1'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -9,19 +9,19 @@ public enum SDKInfo {
  */
 public enum WebRTCInfo {
     /// WebRTC フレームワークのバージョン
-    public static let version = "M129"
+    public static let version = "M132"
 
     /// WebRTC の branch-heads
-    public static let branch = "6668"
+    public static let branch = "6834"
 
     /// WebRTC フレームワークのコミットポジション
-    public static let commitPosition = "1"
+    public static let commitPosition = "5"
 
     /// WebRTC フレームワークのメンテナンスバージョン
-    public static let maintenanceVersion = "0"
+    public static let maintenanceVersion = "1"
 
     /// WebRTC フレームワークのソースコードのリビジョン
-    public static let revision = "21508e08e7545a03c8c35a9299923279e3def319"
+    public static let revision = "afaf497805cbb502da89991c2dcd783201efdd08"
 
     /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
     public static var shortRevision: String {


### PR DESCRIPTION
- [UPDATE] WebRTC m132.6834.5.1 に上げる
 
---

This pull request includes updates to the WebRTC version and related configurations across multiple files. The most important changes involve updating the WebRTC version, checksums, and related metadata.

### WebRTC Version Update:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R15): Updated WebRTC version to `m132.6834.5.1` and added additional contributor.
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6): Updated WebRTC version, file path, and checksum. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL19-R19)
* [`Podfile`](diffhunk://#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cbL8-R8): Updated WebRTC version to `132.6834.5.1`.
* [`Podfile.dev`](diffhunk://#diff-3c49ded39aba3ab23c6fa84f595084cdcf5d219729912f355a7eb24895cbfeeaL8-R8): Updated WebRTC version to `132.6834.5.1`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated WebRTC version badge to `132.6834`.
* [`Sora.podspec`](diffhunk://#diff-74da782083bbd46f709bd607809c5d9f9fe4294a93679382cb722d3e22762067L18-R18): Updated WebRTC dependency version to `132.6834.5.1`.
* [`Sora/PackageInfo.swift`](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbL12-R24): Updated WebRTC version details including branch, commit position, and revision.