### PR TITLE
非公開 API が含まれていた場合エラーにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
         pod install
         if nm ./Pods/WebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/WebRTC | grep _kVTVideoEncoderSpecification_RequiredLowLatency >/dev/null 2>&1; then
           echo 'Error: Non-public API detected in WebRTC framework.'
-          rm -rf Pods/ Podfile.lock
           exit 1
         fi
     - name: Build Xcode Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         pod install
         if nm ./Pods/WebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/WebRTC | grep _kVTVideoEncoderSpecification_RequiredLowLatency >/dev/null 2>&1; then
           echo 'Error: Non-public API detected in WebRTC framework.'
-          rm -rf Pods/ Podfile.lock Sora.xcworkspace/
+          rm -rf Pods/ Podfile.lock
           exit 1
         fi
     - name: Build Xcode Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         rm Podfile && mv Podfile.dev Podfile
         pod repo update
         pod install
+        nm ./Pods/WebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/WebRTC | grep _kVTVideoEncoderSpecification_RequiredLowLatency >/dev/null 2>&1 && echo 'Non-public API' 2>/dev/null && exit 1; rm -rf Pods/ Podfile.lock Sora.xcworkspace/
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
         pod install
         if nm ./Pods/WebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/WebRTC | grep _kVTVideoEncoderSpecification_RequiredLowLatency >/dev/null 2>&1; then
           echo 'Error: Non-public API detected in WebRTC framework.'
+          rm -rf Pods/ Podfile.lock Sora.xcworkspace/
           exit 1
         fi
-        rm -rf Pods/ Podfile.lock Sora.xcworkspace/
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,11 @@ jobs:
         rm Podfile && mv Podfile.dev Podfile
         pod repo update
         pod install
-        nm ./Pods/WebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/WebRTC | grep _kVTVideoEncoderSpecification_RequiredLowLatency >/dev/null 2>&1 && echo 'Non-public API' 2>/dev/null && exit 1; rm -rf Pods/ Podfile.lock Sora.xcworkspace/
+        if nm ./Pods/WebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/WebRTC | grep _kVTVideoEncoderSpecification_RequiredLowLatency >/dev/null 2>&1; then
+          echo 'Error: Non-public API detected in WebRTC framework.'
+          exit 1
+        fi
+        rm -rf Pods/ Podfile.lock Sora.xcworkspace/
     - name: Build Xcode Project
       run: |
         set -o pipefail && \


### PR DESCRIPTION
CI 実行時に依存パッケージに非公開 API が含まれていた場合エラーにするようにしました。
非公開 API が含まれていると Apple の審査が通らないため、事前に確認することを目的としています。

今回追加したのは `_kVTVideoEncoderSpecification_RequiredLowLatency` をチェックするようにしています。

----
This pull request includes an important change to the `jobs:` section in the `.github/workflows/build.yml` file. The change introduces a check for non-public APIs in the WebRTC framework during the build process.

Build process improvement:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R38-R42): Added a check to detect the presence of the `_kVTVideoEncoderSpecification_RequiredLowLatency` symbol in the WebRTC framework. If detected, the build process will output an error message, remove the `Pods/`, `Podfile.lock`, and `Sora.xcworkspace/` directories, and exit with an error status.