### PR TITLE
multistreamEnabled を非推奨扱いにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+- [UPDATE] multistreamEnabled を非推奨扱いにする
+  - multistreamEnabled の設定が不要なイニシャライザを `Configuration` に追加する
+  - ドキュメントコメントに非推奨扱いの旨を追加する
+  - @zztkm
+
 ## 2025.1.1
 
 **リリース日**: 2025-01-23

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -89,13 +89,13 @@ public struct Configuration {
     ///
     /// レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します
     /// そのため、multistreamEnabled は使用は非推奨です
-    public var multistreamEnabled: Bool
+    public var multistreamEnabled: Bool?
 
     /// :nodoc:
     var isMultistream: Bool {
         switch role {
         default:
-            return multistreamEnabled
+            return multistreamEnabled ?? true
         }
     }
 
@@ -229,43 +229,12 @@ public struct Configuration {
      - parameter url: サーバーの URL
      - parameter channelId: チャネル ID
      - parameter role: ロール
-     */
-    public init(url: URL,
-                channelId: String,
-                role: Role)
-    {
-        urlCandidates = [url]
-        self.channelId = channelId
-        self.role = role
-    }
-
-    /**
-     初期化します。
-     - parameter urlCandidates: シグナリングに利用する URL の候補
-     - parameter channelId: チャネル ID
-     - parameter role: ロール
-     */
-    public init(urlCandidates: [URL],
-                channelId: String,
-                role: Role)
-    {
-        self.urlCandidates = urlCandidates
-        self.channelId = channelId
-        self.role = role
-    }
-
-    /**
-     初期化します。
-
-     - parameter url: サーバーの URL
-     - parameter channelId: チャネル ID
-     - parameter role: ロール
-     - parameter multistreamEnabled: マルチストリームの可否
+     - parameter multistreamEnabled: マルチストリームの可否(デフォルトは指定なし)
      */
     public init(url: URL,
                 channelId: String,
                 role: Role,
-                multistreamEnabled: Bool)
+                multistreamEnabled: Bool? = nil)
     {
         urlCandidates = [url]
         self.channelId = channelId
@@ -278,12 +247,12 @@ public struct Configuration {
      - parameter urlCandidates: シグナリングに利用する URL の候補
      - parameter channelId: チャネル ID
      - parameter role: ロール
-     - parameter multistreamEnabled: マルチストリームの可否
+     - parameter multistreamEnabled: マルチストリームの可否(デフォルトは指定なし)
      */
     public init(urlCandidates: [URL],
                 channelId: String,
                 role: Role,
-                multistreamEnabled: Bool)
+                multistreamEnabled: Bool? = nil)
     {
         self.urlCandidates = urlCandidates
         self.channelId = channelId

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -86,6 +86,9 @@ public struct Configuration {
     public var role: Role
 
     /// マルチストリームの可否
+    ///
+    /// レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します
+    /// そのため、multistreamEnabled は使用は非推奨です
     public var multistreamEnabled: Bool
 
     /// :nodoc:
@@ -219,6 +222,37 @@ public struct Configuration {
     /// パブリッシャーの音声トラックの ID です。
     /// 通常、指定する必要はありません。
     public var publisherAudioTrackId: String = defaultPublisherAudioTrackId
+
+    /**
+     初期化します。
+
+     - parameter url: サーバーの URL
+     - parameter channelId: チャネル ID
+     - parameter role: ロール
+     */
+    public init(url: URL,
+                channelId: String,
+                role: Role)
+    {
+        urlCandidates = [url]
+        self.channelId = channelId
+        self.role = role
+    }
+
+    /**
+     初期化します。
+     - parameter urlCandidates: シグナリングに利用する URL の候補
+     - parameter channelId: チャネル ID
+     - parameter role: ロール
+     */
+    public init(urlCandidates: [URL],
+                channelId: String,
+                role: Role)
+    {
+        self.urlCandidates = urlCandidates
+        self.channelId = channelId
+        self.role = role
+    }
 
     /**
      初期化します。

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -88,7 +88,7 @@ public struct Configuration {
     /// マルチストリームの可否
     ///
     /// レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します
-    /// そのため、multistreamEnabled は使用は非推奨です
+    /// そのため、multistreamEnabled の使用は非推奨です
     public var multistreamEnabled: Bool?
 
     /// :nodoc:

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -294,7 +294,10 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
                      message: "did connect to signaling channel")
 
         var role: SignalingRole
-        var multistream = configuration.multistreamEnabled || configuration.spotlightEnabled == .enabled
+        var multistream = configuration.multistreamEnabled
+        if configuration.spotlightEnabled == .enabled {
+            multistream = true
+        }
         switch configuration.role {
         case .sendonly:
             role = .sendonly

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -272,7 +272,7 @@ public struct SignalingConnect {
     /// マルチストリームの可否
     ///
     /// レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します
-    /// そのため、multistreamEnabled は使用は非推奨です
+    /// そのため、multistreamEnabled の使用は非推奨です
     public var multistreamEnabled: Bool?
 
     /// 映像の可否

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -270,6 +270,9 @@ public struct SignalingConnect {
     public var sdp: String?
 
     /// マルチストリームの可否
+    ///
+    /// レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します
+    /// そのため、multistreamEnabled は使用は非推奨です
     public var multistreamEnabled: Bool?
 
     /// 映像の可否


### PR DESCRIPTION
- [UPDATE] multistreamEnabled を非推奨扱いにする
  - multistreamEnabled の設定が不要なイニシャライザを `Configuration` に追加する
  - ドキュメントコメントに非推奨扱いの旨を追加する

---

This pull request deprecates the `multistreamEnabled` setting in the `Configuration` struct and updates related documentation and initializers to reflect this change. The most important changes include marking `multistreamEnabled` as optional, updating initializers to handle the optional type, and modifying the logic to accommodate the deprecation.

Deprecation of `multistreamEnabled`:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R18): Added an entry to mark `multistreamEnabled` as deprecated and updated documentation comments accordingly.
* [`Sora/Configuration.swift`](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L89-R98): Updated the `multistreamEnabled` property to be optional and modified related documentation comments to indicate its deprecation. [[1]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L89-R98) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R273-R275)

Initializer updates:

* [`Sora/Configuration.swift`](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L229-R237): Modified initializers to accept an optional `multistreamEnabled` parameter with a default value of `nil`. [[1]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L229-R237) [[2]](diffhunk://#diff-9ba546f38c010675e7eb1513335dd64c544d273169911a0af32f0d7b2164f958L247-R255)

Logic adjustments:

* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L297-R300): Updated the logic to handle the optional `multistreamEnabled` property and ensure compatibility with the `spotlightEnabled` setting.
