### PR TITLE
設定に応じて multistreamEnabled の値を更新する処理を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 ## develop
 
-- [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する
+- [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更
   - Configration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除
   - Configration.spotlightEnabled に .enabled を指定している場合に multistream を true に更新する処理を削除
   - 結果、connect メッセージには Configration.multistreamEnabled に指定した値が送信される

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,11 @@
 
 ## develop
 
-- [CHANGE] 設定に応じて multistreamEnabled の値を更新する処理を削除する
+- [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する
+  - Configration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除
+  - Configration.spotlightEnabled に .enabled を指定している場合に multistream を true に更新する処理を削除
+  - 結果、connect メッセージには Configration.multistreamEnabled に指定した値が送信される
+  - 今後は Configration.role に .sendrecv を指定している場合または Configration.spotlightEnabled に .enabled を指定している場合に Confgration.multistreamEnabled に false を指定すると接続エラーになる 
   - @zztkm
 - [UPDATE] multistreamEnabled を非推奨扱いにする
   - multistreamEnabled の設定が不要なイニシャライザを `Configuration` に追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [CHANGE] 設定に応じて multistreamEnabled の値を更新する処理を削除する
+  - @zztkm
 - [UPDATE] multistreamEnabled を非推奨扱いにする
   - multistreamEnabled の設定が不要なイニシャライザを `Configuration` に追加する
   - ドキュメントコメントに非推奨扱いの旨を追加する

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -293,12 +293,22 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         Logger.debug(type: .peerChannel,
                      message: "did connect to signaling channel")
 
+        var role: SignalingRole
+        switch configuration.role {
+        case .sendonly:
+            role = .sendonly
+        case .recvonly:
+            role = .recvonly
+        case .sendrecv:
+            role = .sendrecv
+        }
+
         let soraClient = "Sora iOS SDK \(SDKInfo.version)"
         let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version.dropFirst()).\(WebRTCInfo.branch).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
 
         let simulcast = configuration.simulcastEnabled
         let connect = SignalingConnect(
-            role: configuration.role,
+            role: role,
             channelId: configuration.channelId,
             clientId: configuration.clientId,
             bundleId: configuration.bundleId,

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -293,35 +293,19 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         Logger.debug(type: .peerChannel,
                      message: "did connect to signaling channel")
 
-        var role: SignalingRole
-        var multistream = configuration.multistreamEnabled
-        if configuration.spotlightEnabled == .enabled {
-            multistream = true
-        }
-        switch configuration.role {
-        case .sendonly:
-            role = .sendonly
-        case .recvonly:
-            role = .recvonly
-        case .sendrecv:
-            role = .sendrecv
-            multistream = true
-        }
-
         let soraClient = "Sora iOS SDK \(SDKInfo.version)"
-
         let webRTCVersion = "Shiguredo-build \(WebRTCInfo.version) (\(WebRTCInfo.version.dropFirst()).\(WebRTCInfo.branch).\(WebRTCInfo.commitPosition).\(WebRTCInfo.maintenanceVersion) \(WebRTCInfo.shortRevision))"
 
         let simulcast = configuration.simulcastEnabled
         let connect = SignalingConnect(
-            role: role,
+            role: configuration.role,
             channelId: configuration.channelId,
             clientId: configuration.clientId,
             bundleId: configuration.bundleId,
             metadata: configuration.signalingConnectMetadata,
             notifyMetadata: configuration.signalingConnectNotifyMetadata,
             sdp: sdp,
-            multistreamEnabled: multistream,
+            multistreamEnabled: configuration.multistreamEnabled,
             videoEnabled: configuration.videoEnabled,
             videoCodec: configuration.videoCodec,
             videoBitRate: configuration.videoBitRate,


### PR DESCRIPTION
- [CHANGE] 設定に応じて multistreamEnabled の値を更新する処理を削除する

---

This pull request includes changes to deprecate the `multistreamEnabled` setting and update its handling in the codebase. The most important changes include removing the update process for `multistreamEnabled` based on other configurations and marking it as deprecated in the documentation.

Deprecation of `multistreamEnabled`:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R15): Removed the process that updates the `multistreamEnabled` value based on configurations and marked `multistreamEnabled` as deprecated.

Codebase updates:

* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L297-L312): Removed code that conditionally updated the `multistream` variable based on other configurations and directly used `configuration.multistreamEnabled` instead. [[1]](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L297-L312) [[2]](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457L324-R318)