### PR TITLE
 scaleResolutionDownTo 追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
+  - @zztkm
 - [UPDATE] WebRTC m132.6834.5.3 に上げる
   - @zztkm
 - [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1207,6 +1207,11 @@ extension RTCRtpSender {
                     Logger.debug(type: .peerChannel, message: "scaleResolutionDownBy: \(value)")
                     oldEncoding.scaleResolutionDownBy = NSNumber(value: value)
                 }
+                
+                if let value = encoding.scaleResolutionDownTo {
+                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownTo: \(ObjectIdentifier(value))")
+                    oldEncoding.scaleResolutionDownTo = value
+                }
 
                 if let value = encoding.scalabilityMode {
                     Logger.debug(type: .peerChannel, message: "scalabilityMode: \(value)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1354,7 +1354,9 @@ extension RTCRtpSender {
                 }
 
                 if let value = encoding.scaleResolutionDownTo {
-                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownTo: \(value.maxWidth)x\(value.maxHeight)")
+                    Logger.debug(
+                        type: .peerChannel,
+                        message: "scaleResolutionDownTo: \(value.maxWidth)x\(value.maxHeight)")
                     oldEncoding.scaleResolutionDownTo = value
                 }
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1207,7 +1207,7 @@ extension RTCRtpSender {
                     Logger.debug(type: .peerChannel, message: "scaleResolutionDownBy: \(value)")
                     oldEncoding.scaleResolutionDownBy = NSNumber(value: value)
                 }
-                
+
                 if let value = encoding.scaleResolutionDownTo {
                     Logger.debug(type: .peerChannel, message: "scaleResolutionDownTo: \(ObjectIdentifier(value))")
                     oldEncoding.scaleResolutionDownTo = value

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1357,7 +1357,8 @@ extension RTCRtpSender {
                     Logger.debug(
                         type: .peerChannel,
                         message: "scaleResolutionDownTo: \(value.maxWidth)x\(value.maxHeight)")
-                    oldEncoding.scaleResolutionDownTo = value
+                    oldEncoding.scaleResolutionDownTo?.maxWidth = value.maxWidth
+                    oldEncoding.scaleResolutionDownTo?.maxHeight = value.maxHeight
                 }
 
                 if let value = encoding.scalabilityMode {

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1209,7 +1209,7 @@ extension RTCRtpSender {
                 }
 
                 if let value = encoding.scaleResolutionDownTo {
-                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownTo: \(ObjectIdentifier(value))")
+                    Logger.debug(type: .peerChannel, message: "scaleResolutionDownTo: \(value.maxWidth)x\(value.maxHeight)")
                     oldEncoding.scaleResolutionDownTo = value
                 }
 

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -987,7 +987,7 @@ extension SignalingOffer.Configuration: Codable {
     }
 }
 
-fileprivate struct ScaleResolutionDownTo {
+private struct ScaleResolutionDownTo {
     fileprivate let maxWidth: Int
     fileprivate let maxHeight: Int
 }
@@ -997,7 +997,7 @@ extension ScaleResolutionDownTo: Codable {
         case maxWidth
         case maxHeight
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         maxWidth = try container.decode(Int.self, forKey: .maxWidth)
@@ -1016,7 +1016,7 @@ extension SignalingOffer.Encoding: Codable {
         case scaleResolutionDownTo
         case scalabilityMode
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         rid = try container.decodeIfPresent(String.self, forKey: .rid)
@@ -1024,8 +1024,8 @@ extension SignalingOffer.Encoding: Codable {
         maxBitrate = try container.decodeIfPresent(Int.self, forKey: .maxBitrate)
         maxFramerate = try container.decodeIfPresent(Double.self, forKey: .maxFramerate)
         scaleResolutionDownBy = try container.decodeIfPresent(Double.self, forKey: .scaleResolutionDownBy)
-        
-        if let _scleResolutionDownTo  = try container.decodeIfPresent(ScaleResolutionDownTo.self, forKey: .scaleResolutionDownTo) {
+
+        if let _scleResolutionDownTo = try container.decodeIfPresent(ScaleResolutionDownTo.self, forKey: .scaleResolutionDownTo) {
             let restriction = RTCResolutionRestriction()
             restriction.maxWidth = NSNumber(value: _scleResolutionDownTo.maxWidth)
             restriction.maxHeight = NSNumber(value: _scleResolutionDownTo.maxHeight)
@@ -1033,7 +1033,7 @@ extension SignalingOffer.Encoding: Codable {
         } else {
             scaleResolutionDownTo = nil
         }
-        
+
         scalabilityMode = try container.decodeIfPresent(String.self, forKey: .scalabilityMode)
     }
 

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -976,7 +976,7 @@ extension SignalingOffer.Configuration: Codable {
 }
 
 /// scaleResolutionDownTo を JSON デコードする専用の構造体
-fileprivate struct ScaleResolutionDownTo {
+private struct ScaleResolutionDownTo {
     fileprivate let maxWidth: Int
     fileprivate let maxHeight: Int
 }
@@ -1015,7 +1015,9 @@ extension SignalingOffer.Encoding: Codable {
         scaleResolutionDownBy = try container.decodeIfPresent(
             Double.self,
             forKey: .scaleResolutionDownBy)
-        if let _scleResolutionDownTo = try container.decodeIfPresent(ScaleResolutionDownTo.self, forKey: .scaleResolutionDownTo) {
+        if let _scleResolutionDownTo = try container.decodeIfPresent(
+            ScaleResolutionDownTo.self, forKey: .scaleResolutionDownTo)
+        {
             let restriction = RTCResolutionRestriction()
             restriction.maxWidth = NSNumber(value: _scleResolutionDownTo.maxWidth)
             restriction.maxHeight = NSNumber(value: _scleResolutionDownTo.maxHeight)

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -378,7 +378,7 @@ public struct SignalingOffer {
         /// 映像解像度を送信前に下げる度合
         public let scaleResolutionDownBy: Double?
 
-        /// エンコーディングを制限する最大の寸法
+        /// エンコーディングを制限する最大のサイズ
         public let scaleResolutionDownTo: RTCResolutionRestriction?
 
         /// scalability mode

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -388,7 +388,7 @@ public struct SignalingOffer {
         /// 映像解像度を送信前に下げる度合
         public let scaleResolutionDownBy: Double?
 
-        /// 解像度の
+        /// エンコーディングを制限する最大の寸法
         public let scaleResolutionDownTo: RTCResolutionRestriction?
 
         /// scalability mode
@@ -987,7 +987,8 @@ extension SignalingOffer.Configuration: Codable {
     }
 }
 
-private struct ScaleResolutionDownTo {
+/// scaleResolutionDownTo を JSON デコードする専用の構造体
+fileprivate struct ScaleResolutionDownTo {
     fileprivate let maxWidth: Int
     fileprivate let maxHeight: Int
 }

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -398,7 +398,8 @@ public struct SignalingOffer {
                 params.scaleResolutionDownBy = NSNumber(value: value)
             }
             if let value = scaleResolutionDownTo {
-                params.scaleResolutionDownTo = value
+                params.scaleResolutionDownTo?.maxWidth = value.maxWidth
+                params.scaleResolutionDownTo?.maxHeight = value.maxHeight
             }
             params.scalabilityMode = scalabilityMode
             return params


### PR DESCRIPTION
- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する

---

This pull request includes changes to add a new encoding parameter, `scaleResolutionDownTo`, for simulcast video in the WebRTC implementation. The changes involve updates to both the documentation and the codebase to support this new parameter.

### Documentation Updates:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R17): Added an entry for the new encoding parameter `scaleResolutionDownTo`.

### Codebase Updates:
* [`Sora/PeerChannel.swift`](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457R1356-R1363): Added support for logging and setting the `scaleResolutionDownTo` parameter in the `RTCRtpSender` extension.
* `Sora/Signaling.swift`:
  * `SignalingOffer` struct: Added the `scaleResolutionDownTo` property.
  * `SignalingOffer` struct: Updated the `toParameters` method to include the `scaleResolutionDownTo` parameter.
  * [`SignalingOffer.Configuration`](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R978-R996): Added a private struct `ScaleResolutionDownTo` for JSON decoding and updated the `Codable` extension to handle this new parameter. [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R978-R996) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R1005) [[3]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R1018-R1027)