### PR TITLE
libwebrtc を m132.6834.5.7 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 ## develop
 
-- [UPDATE] WebRTC m132.6834.5.3 に上げる
+- [UPDATE] WebRTC m132.6834.5.7 に上げる
   - @zztkm
 - [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更
   - Configration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let file = "WebRTC-132.6834.5.3/WebRTC.xcframework.zip"
+let file = "WebRTC-132.6834.5.7/WebRTC.xcframework.zip"
 
 let package = Package(
     name: "Sora",
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/\(file)",
-            checksum: "99444703b581fc51601f8a061eda544a7c5c5f597120b89a3436fc9da0b5b3f7"
+            checksum: "c19d8b32a0a34295d96acd5458ea6b07cff4e7e32cbd7b5ddef945fb3b780f30"
         ),
         .target(
             name: "Sora",

--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '14.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '132.6834.5.3'
+  pod 'WebRTC', '132.6834.5.7'
 end

--- a/Podfile.dev
+++ b/Podfile.dev
@@ -5,6 +5,6 @@ platform :ios, '14.0'
 
 target 'Sora' do
   use_frameworks!
-  pod 'WebRTC', '132.6834.5.3'
+  pod 'WebRTC', '132.6834.5.7'
   pod 'SwiftLint', '0.51.0'
 end

--- a/Sora.podspec
+++ b/Sora.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source_files = "Sora/**/*.swift"
   s.resources = ['Sora/*.xib']
-  s.dependency "WebRTC", '132.6834.5.3'
+  s.dependency "WebRTC", '132.6834.5.7'
   s.pod_target_xcconfig = {
     'ARCHS' => 'arm64',
     'ARCHS[config=Debug]' => '$(ARCHS_STANDARD)'

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -16,7 +16,7 @@ public enum WebRTCInfo {
     public static let commitPosition = "5"
 
     /// WebRTC フレームワークのメンテナンスバージョン
-    public static let maintenanceVersion = "3"
+    public static let maintenanceVersion = "7"
 
     /// WebRTC フレームワークのソースコードのリビジョン
     public static let revision = "afaf497805cbb502da89991c2dcd783201efdd08"


### PR DESCRIPTION
- [UPDATE] WebRTC m132.6834.5.7 に上げる

---

This pull request includes updates to the WebRTC framework version across multiple files to ensure consistency and compatibility with the latest version. The most important changes include updating the WebRTC version in various configuration files and documentation.

Version updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R14): Updated the WebRTC version from `m132.6834.5.3` to `m132.6834.5.7`.
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6): Updated the WebRTC file path and checksum to reflect the new version `132.6834.5.7`. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL19-R19)
* [`Podfile`](diffhunk://#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cbL8-R8): Updated the WebRTC pod version to `132.6834.5.7`.
* [`Podfile.dev`](diffhunk://#diff-3c49ded39aba3ab23c6fa84f595084cdcf5d219729912f355a7eb24895cbfeeaL8-R8): Updated the WebRTC pod version to `132.6834.5.7`.
* [`Sora.podspec`](diffhunk://#diff-74da782083bbd46f709bd607809c5d9f9fe4294a93679382cb722d3e22762067L18-R18): Updated the WebRTC dependency to version `132.6834.5.7`.
* [`Sora/PackageInfo.swift`](diffhunk://#diff-c5d413f60acf7ce97a6841dc8c803506f2a5345114f051d60989b5b3c4ba66cbL19-R19): Updated the WebRTC maintenance version from `3` to `7`.