### PR TITLE
SwiftLint を Swift Package Manager で管理する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
   - @zztkm
 - [UPDATE] GitHub Actions で format check をするのをやめる
   - @zztkm
+- [UPDATE] SwiftLint の管理を CocoaPods から Swift Package Manager に移行する
+  - @zztkm
 
 ## 2025.1.1
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftLintPlugins",
+        "repositoryURL": "https://github.com/SimplyDanny/SwiftLintPlugins",
+        "state": {
+          "branch": null,
+          "revision": "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
+          "version": "0.58.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,11 @@ let package = Package(
         .library(name: "Sora", targets: ["Sora"]),
         .library(name: "WebRTC", targets: ["WebRTC"]),
     ],
+    dependencies: [
+        // 開発用依存関係
+        // SwfitLint 公式で推奨されている SwfitLintPlugins を利用する
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.58.2")
+    ],
     targets: [
         .binaryTarget(
             name: "WebRTC",

--- a/lint-format.sh
+++ b/lint-format.sh
@@ -4,17 +4,13 @@
 # 未フォーマットか lint でルール違反を検出したら終了ステータス 1 を返す
 # GitHub Actions では未フォーマット箇所の有無の確認に使う
 
-PODS_ROOT=Pods
-SRCROOT=.
-LINT=${PODS_ROOT}/SwiftLint/swiftlint
-
 # フォーマットリントは未フォーマットでもステータスコード 0 を返すので
 # ステータスコードチェックを行わない
 swift format lint -r Sora SoraTests
 swift format -i -r Sora SoraTests
 
-$LINT --fix $SRCROOT
-$LINT --strict $SRCROOT
+swift package plugin  --allow-writing-to-package-directory swiftlint --fix .
+swift package plugin  --allow-writing-to-package-directory swiftlint --strict .
 lint=$?
 
 test $lint -eq 0


### PR DESCRIPTION
- [UPDATE] SwiftLint の管理を CocoaPods から Swift Package Manager に移行する

---

This pull request includes changes to migrate SwiftLint management from CocoaPods to Swift Package Manager, update dependencies, and modify the linting script. The most important changes are summarized below:

Migration to Swift Package Manager:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R35-R36): Updated to reflect the migration of SwiftLint management from CocoaPods to Swift Package Manager.
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR15-R19): Added SwiftLintPlugins as a development dependency to manage SwiftLint via Swift Package Manager.

Updates to linting script:

* [`lint-format.sh`](diffhunk://#diff-9538e072ccdd9c2d02adb3c867a500c09102460cc43200d3384a0e7563e9c4c6L7-R13): Updated the script to use SwiftLint via Swift Package Manager plugins instead of CocoaPods. Removed old references to CocoaPods paths and commands.