### PR TITLE
swift-format と SwiftLint 実行用の Makefile を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@
 - [UPDATE] 開発用の依存管理を Swift Package Manager に移行したので Podfile.dev を削除する
   - GitHub Actions でも Podfile.dev を利用していたので、利用しないように変更
   - @zztkm
+- [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
+  - lint-format.sh で実行していたコマンドを個別に実行できるようにした
+  - @zztkm
 
 ## 2025.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: fmt fmt-lint lint
 
-# フォーマット (swift-format)
+# swift-format
 fmt:
 	swift format --in-place --recursive Sora SoraTests
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fmt:
 fmt-lint:
 	swift format lint --strict --parallel --recursive Sora SoraTests
 
-# Lint (SwiftLint)
+# SwiftLint
 lint:
 	swift package plugin --allow-writing-to-package-directory swiftlint --fix .
 	swift package plugin --allow-writing-to-package-directory swiftlint --strict .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: fmt fmt-lint lint
+
+# フォーマット (swift-format)
+fmt:
+	swift format --in-place --recursive Sora SoraTests
+
+# フォーマットリント (swift-format)
+fmt-lint:
+	swift format lint --strict --parallel --recursive Sora SoraTests
+
+# Lint (SwiftLint)
+lint:
+	swift package plugin --allow-writing-to-package-directory swiftlint --fix .
+	swift package plugin --allow-writing-to-package-directory swiftlint --strict .
+
+# すべてを実行
+all: fmt-lint fmt lint

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 fmt:
 	swift format --in-place --recursive Sora SoraTests
 
-# フォーマットリント (swift-format)
+# swift-format lint
 fmt-lint:
 	swift format lint --strict --parallel --recursive Sora SoraTests
 


### PR DESCRIPTION
- [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
  - lint-format.sh で実行していたコマンドを個別に実行できるようにした

---

This pull request includes updates to the dependency management and the addition of a Makefile for formatting and linting Swift code. The most important changes include the removal of `Podfile.dev`, updates to GitHub Actions, and the addition of commands for `swift-format` and `SwiftLint` in the Makefile.

Dependency management updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R42-R44): Removed `Podfile.dev` due to migration to Swift Package Manager and updated GitHub Actions to stop using `Podfile.dev`.

Makefile additions:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R17): Added commands for `swift-format` and `SwiftLint`, allowing individual execution of these commands and a combined `all` command to run all checks.