### PR TITLE
Sora から切断された場合の切断処理を改善する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,19 +11,24 @@
 
 ## develop
 
-- [UPDATE] WebRTC m132.6834.5.7 に上げる
-  - @zztkm
-- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
-  - @zztkm
 - [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更
   - Configration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除
   - Configration.spotlightEnabled に .enabled を指定している場合に multistream を true に更新する処理を削除
   - 結果、connect メッセージには Configration.multistreamEnabled に指定した値が送信される
   - 今後は Configration.role に .sendrecv を指定している場合または Configration.spotlightEnabled に .enabled を指定している場合に Confgration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
+- [UPDATE] WebRTC m132.6834.5.7 に上げる
+  - @zztkm
 - [UPDATE] multistreamEnabled を非推奨扱いにする
   - `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
   - ドキュメントコメントに非推奨扱いの旨を追加する
+  - @zztkm
+- [UPDATE] Sora から切断された場合の切断処理を改善する
+  - Sora から Close Frame を受けとった場合にステータスコードと理由を `MediaChannelHandlers.onDisconnect` で返すようになった
+  - ネットワークエラーや Sora がダウンした場合のエラー内容を `MediaChannelHandlers.onDisconnect` で返すようになった
+  - いままでは WebSocket メッセージ受信失敗時のエラーである `The operation couldn’t be completed. Socket is not connected` というエラーしか返せていなかった状態が改善された
+  - @zztkm
+- [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
   - ドキュメントコメントに非推奨扱いの旨を追加する
   - @zztkm
 - [UPDATE] Sora から切断された場合の切断処理を改善する
-  - Sora から Close Frame を受けとった場合にステータスコードと理由を `MediaChannelHandlers.onDisconnect` で返すようになった
+  - Sora から Close Frame を受け取った場合にステータスコードと理由を `MediaChannelHandlers.onDisconnect` で返すようになった
   - ネットワークエラーや Sora がダウンした場合のエラー内容を `MediaChannelHandlers.onDisconnect` で返すようになった
   - いままでは WebSocket メッセージ受信失敗時のエラーである `The operation couldn’t be completed. Socket is not connected` というエラーしか返せていなかった状態が改善された
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,12 +22,14 @@
 - [UPDATE] `Configuration.multistreamEnabled` を非推奨にする
   - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
   - @zztkm
-- [UPDATE] Sora から切断された場合の切断処理を改善する
-  - Sora から Close Frame を受け取った場合にステータスコードと理由を `MediaChannelHandlers.onDisconnect` で返すようになった
-  - ネットワークエラーや Sora がダウンした場合のエラー内容を `MediaChannelHandlers.onDisconnect` で返すようになった
-  - いままでは WebSocket メッセージ受信失敗時のエラーである `The operation couldn’t be completed. Socket is not connected` というエラーしか返せていなかった状態が改善された
-  - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
+  - @zztkm
+- [FIX] Sora から切断された場合の切断処理を修正し適切なエラーを ``MediaChannelHandlers.onDisconnect`` で受け取ることができるようにする
+  - Sora iOS SDK 2025.1.1 までは Sora から Close Frame を受け取ったり、ネットワークエラーが起きたりしても、WebSocket メッセージ受信失敗に起因する ``SoraError.webSocketError`` しか受信できなかったが、以下の内容を受信できるようになった
+    - Sora から Close Frame を受け取った場合のステータスコードと理由
+      - ステータスコードが 1000 で正常に切断された場合も ``MediaChannelHandlers.onDisconnect`` で通知する
+    - ネットワークエラーや Sora がダウンした場合のエラー内容
+  - この変更によって ``MediaChannelHandlers.onDisconnect`` で受信するメッセージの内容は変わるが、コールバックが発火するタイミングに変更はない
   - @zztkm
 
 ### misc

--- a/Sora/SignalingChannel.swift
+++ b/Sora/SignalingChannel.swift
@@ -146,7 +146,8 @@ class SignalingChannel {
       }
     }
 
-    // エラー発生時
+    // WebSocket 切断時
+    // 正常に切断したときも error は nil にならない
     ws.internalHandlers.onDisconnectWithError = { [weak self] ws, error in
       guard let weakSelf = self else {
         return

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -124,6 +124,9 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
   }
 
   func receive() {
+    Logger.debug(
+      type: .webSocketChannel, message: "[\(host)] \(String(describing: webSocketTask?.closeCode))]"
+    )
     if webSocketTask?.closeCode != URLSessionWebSocketTask.CloseCode.invalid {
       Logger.debug(type: .webSocketChannel, message: "[\(host)] already closed")
       return

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -124,12 +124,6 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
   }
 
   func receive() {
-    if webSocketTask?.closeCode != URLSessionWebSocketTask.CloseCode.invalid {
-      Logger.debug(type: .webSocketChannel, message: "[\(host)] already closed")
-      return
-    }
-    Logger.debug(type: .webSocketChannel, message: "\(webSocketTask?.closeCode.rawValue)")
-
     webSocketTask?.receive { [weak self] result in
       guard let weakSelf = self else {
         return
@@ -168,17 +162,7 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
         weakSelf.receive()
 
       case .failure(let error):
-        // TODO(zztkm): Sora から切断されたときに、close frame を処理するメソッド呼び出しより前に failure が起こるのは想定外なので原因を調べる
-        // close frame 処理の参考: https://developer.apple.com/documentation/foundation/urlsessionwebsocketdelegate/3181188-urlsession
-        // 余計なログを出力しないために、 disconnect の前にチェックする
-        guard !weakSelf.isClosing else {
-          return
-        }
-
-        Logger.debug(
-          type: .webSocketChannel,
-          message: "[\(weakSelf.host)] failed => \(error.localizedDescription)")
-        weakSelf.disconnect(error: SoraError.webSocketError(error))
+        break
       }
     }
   }

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -98,10 +98,10 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     var nativeMessage: URLSessionWebSocketTask.Message!
     switch message {
     case .text(let text):
-      Logger.debug(type: .webSocketChannel, message: text)
+      Logger.debug(type: .webSocketChannel, message: "[\(host)] sending text: \(text)]")
       nativeMessage = .string(text)
     case .binary(let data):
-      Logger.debug(type: .webSocketChannel, message: "[\(host)] \(data)")
+      Logger.debug(type: .webSocketChannel, message: "[\(host)] sending binary: \(data)")
       nativeMessage = .data(data)
     }
     webSocketTask!.send(nativeMessage) { [weak self] error in
@@ -116,7 +116,8 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
 
       if let error {
         Logger.debug(
-          type: .webSocketChannel, message: "[\(weakSelf.host)] failed to send message")
+          type: .webSocketChannel,
+          message: "[\(weakSelf.host)] failed to send message: \(error.localizedDescription)")
         weakSelf.disconnect(error: error)
       }
     }

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -164,12 +164,10 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
         }
 
         weakSelf.receive()
-
       case .failure(let error):
         // メッセージ受信に失敗以上のエラーは urlSession の didCompleteWithError で検知できるのでここではログを出して break する
         Logger.debug(
           type: .webSocketChannel, message: "[\(weakSelf.host)] message receive error: \(error)")
-        break
       }
     }
   }

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -84,6 +84,7 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
       internalHandlers.onDisconnectWithError?(self, error)
     }
 
+    Logger.debug(type: .webSocketChannel, message: "[\(host)] canceling")
     webSocketTask?.cancel(with: .normalClosure, reason: nil)
     urlSession?.invalidateAndCancel()
 
@@ -201,9 +202,12 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
     reason: Data?
   ) {
+    Logger.debug(type: .webSocketChannel, message: "close frame received")
     guard !isClosing else {
       return
     }
+
+    Logger.debug(type: .webSocketChannel, message: "close frame received but not yet closing")
 
     var message = "[\(host)] \(#function) closeCode => \(closeCode)"
 

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -88,7 +88,6 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
       internalHandlers.onDisconnectWithError?(self, error)
     }
 
-    Logger.debug(type: .webSocketChannel, message: "[\(host)] canceling")
     webSocketTask?.cancel(with: .normalClosure, reason: nil)
     urlSession?.invalidateAndCancel()
 
@@ -122,7 +121,7 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
         Logger.debug(
           type: .webSocketChannel,
           message: "[\(weakSelf.host)] failed to send message: \(error.localizedDescription)")
-        weakSelf.disconnect(error: error)
+        weakSelf.disconnect(error: SoraError.webSocketError(error))
       }
     }
   }
@@ -282,6 +281,6 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     guard let error = error else { return }
     Logger.debug(
       type: .webSocketChannel, message: "didCompleteWithError \(error.localizedDescription)")
-    disconnect(error: error)
+    disconnect(error: SoraError.webSocketError(error))
   }
 }

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -124,6 +124,11 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
   }
 
   func receive() {
+    if webSocketTask?.closeCode != URLSessionWebSocketTask.CloseCode.invalid {
+      Logger.debug(type: .webSocketChannel, message: "[\(host)] already closed")
+      return
+    }
+
     webSocketTask?.receive { [weak self] result in
       guard let weakSelf = self else {
         return

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -195,13 +195,11 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
     reason: Data?
   ) {
-    Logger.debug(type: .webSocketChannel, message: "close frame received")
     guard !isClosing else {
       return
     }
 
-    Logger.debug(type: .webSocketChannel, message: "close frame received but not yet closing")
-
+    Logger.debug(type: .webSocketChannel, message: "close frame received")
     var message = "[\(host)] \(#function) closeCode => \(closeCode)"
 
     let reasonString = reason2string(reason: reason)
@@ -217,6 +215,9 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
         statusCode: statusCode,
         reason: reasonString)
       disconnect(error: error)
+    } else {
+      // 正常処理の場合は error なしで disconnect する
+      disconnect(error: nil)
     }
   }
 

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -161,6 +161,8 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
         weakSelf.receive()
 
       case .failure(let error):
+        // TODO(zztkm): Sora から切断されたときに、close frame を処理するメソッド呼び出しより前に failure が起こるのは想定外なので原因を調べる
+        // close frame 処理の参考: https://developer.apple.com/documentation/foundation/urlsessionwebsocketdelegate/3181188-urlsession
         // 余計なログを出力しないために、 disconnect の前にチェックする
         guard !weakSelf.isClosing else {
           return

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -209,16 +209,13 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
 
     Logger.debug(type: .webSocketChannel, message: message)
 
-    if closeCode != .normalClosure {
-      let statusCode = WebSocketStatusCode(rawValue: closeCode.rawValue)
-      let error = SoraError.webSocketClosed(
-        statusCode: statusCode,
-        reason: reasonString)
-      disconnect(error: error)
-    } else {
-      // 正常処理の場合は error なしで disconnect する
-      disconnect(error: nil)
-    }
+    // ステータスコード 1000 の場合でも error として上位層に伝搬させることにする (上位層が error 前提で組まれているためこのような方針にした)
+    // TODO(zztkm): 改修範囲が広くはなるが Sora から正常に Close Frame を受け取った場合は error とは区別して伝搬させたい
+    let statusCode = WebSocketStatusCode(rawValue: closeCode.rawValue)
+    let error = SoraError.webSocketClosed(
+      statusCode: statusCode,
+      reason: reasonString)
+    disconnect(error: error)
   }
 
   func urlSession(

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -124,13 +124,11 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
   }
 
   func receive() {
-    Logger.debug(
-      type: .webSocketChannel, message: "[\(host)] \(String(describing: webSocketTask?.closeCode))]"
-    )
     if webSocketTask?.closeCode != URLSessionWebSocketTask.CloseCode.invalid {
       Logger.debug(type: .webSocketChannel, message: "[\(host)] already closed")
       return
     }
+    Logger.debug(type: .webSocketChannel, message: "\(webSocketTask?.closeCode.rawValue)")
 
     webSocketTask?.receive { [weak self] result in
       guard let weakSelf = self else {

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -101,7 +101,7 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     var nativeMessage: URLSessionWebSocketTask.Message!
     switch message {
     case .text(let text):
-      Logger.debug(type: .webSocketChannel, message: "[\(host)] sending text: \(text)]")
+      Logger.debug(type: .webSocketChannel, message: "[\(host)] sending text: \(text)")
       nativeMessage = .string(text)
     case .binary(let data):
       Logger.debug(type: .webSocketChannel, message: "[\(host)] sending binary: \(data)")

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -69,6 +69,10 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     receive()
   }
 
+  /// WebSocket を切断するメソッド
+  ///
+  /// クライアントから切断する場合は error を nil にする
+  /// Sora から切断されたり、ネットワークエラーが起こったりした場合は error がセットされ、onDisconnectWithError コールバックが発火する
   func disconnect(error: Error?) {
     guard !isClosing else {
       return
@@ -162,6 +166,9 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
         weakSelf.receive()
 
       case .failure(let error):
+        // メッセージ受信に失敗以上のエラーは urlSession の didCompleteWithError で検知できるのでここではログを出して break する
+        Logger.debug(
+          type: .webSocketChannel, message: "[\(weakSelf.host)] message receive error: \(error)")
         break
       }
     }
@@ -209,8 +216,9 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
 
     Logger.debug(type: .webSocketChannel, message: message)
 
-    // ステータスコード 1000 の場合でも error として上位層に伝搬させることにする (上位層が error 前提で組まれているためこのような方針にした)
-    // TODO(zztkm): 改修範囲が広くはなるが Sora から正常に Close Frame を受け取った場合は error とは区別して伝搬させたい
+    // 2025.2.x から、ステータスコード 1000 の場合でも error として上位層に伝搬させることにする (上位層が error 前提で組まれているためこのような方針にした)
+    // これは disconnect が error を渡さないと機能
+    // TODO(zztkm): 改修範囲が広くはなるが Sora から正常に Close Frame を受け取った場合は error とは区別して伝搬させる
     let statusCode = WebSocketStatusCode(rawValue: closeCode.rawValue)
     let error = SoraError.webSocketClosed(
       statusCode: statusCode,
@@ -272,6 +280,7 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
 
   func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     // エラーが発生したときだけ disconnect 処理を投げる
+    // ここで検知されるエラーの原因例: インターネット切断、Sora がダウン
     guard let error = error else { return }
     Logger.debug(
       type: .webSocketChannel, message: "didCompleteWithError \(error.localizedDescription)")

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -214,7 +214,6 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     Logger.debug(type: .webSocketChannel, message: message)
 
     // 2025.2.x から、ステータスコード 1000 の場合でも error として上位層に伝搬させることにする (上位層が error 前提で組まれているためこのような方針にした)
-    // これは disconnect が error を渡さないと機能
     // TODO(zztkm): 改修範囲が広くはなるが Sora から正常に Close Frame を受け取った場合は error とは区別して伝搬させる
     let statusCode = WebSocketStatusCode(rawValue: closeCode.rawValue)
     let error = SoraError.webSocketClosed(

--- a/Sora/URLSessionWebSocketChannel.swift
+++ b/Sora/URLSessionWebSocketChannel.swift
@@ -271,4 +271,12 @@ class URLSessionWebSocketChannel: NSObject, URLSessionDelegate, URLSessionTaskDe
     let credential = URLCredential(user: username, password: password, persistence: .forSession)
     completionHandler(.useCredential, credential)
   }
+
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    // エラーが発生したときだけ disconnect 処理を投げる
+    guard let error = error else { return }
+    Logger.debug(
+      type: .webSocketChannel, message: "didCompleteWithError \(error.localizedDescription)")
+    disconnect(error: error)
+  }
 }


### PR DESCRIPTION
- [FIX] Sora から切断された場合の切断処理を修正し適切なエラーを ``MediaChannelHandlers.onDisconnect`` で受け取ることができるようにする
  - Sora iOS SDK 2025.1.1 までは Sora から Close Frame を受け取ったり、ネットワークエラーが起きたりしても、WebSocket メッセージ受信失敗に起因する ``SoraError.webSocketError`` しか受信できなかったが、以下の内容を受信できるようになった
    - Sora から Close Frame を受け取った場合のステータスコードと理由
      - ステータスコードが 1000 で正常に切断された場合も ``MediaChannelHandlers.onDisconnect`` で通知する
    - ネットワークエラーや Sora がダウンした場合のエラー内容
  - この変更によって ``MediaChannelHandlers.onDisconnect`` で受信するメッセージの内容は変わるが、コールバックが発火するタイミングに変更はないうエラーしか返せていなかった状態が改善された

---

This pull request includes several changes to improve WebSocket handling and error reporting in the `Sora` project. The most important changes focus on enhancing the disconnect process and improving logging for WebSocket operations.

### Improvements to WebSocket handling and error reporting:

* [`Sora/URLSessionWebSocketChannel.swift`](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebR72-R75): Added a method to handle WebSocket disconnection, including handling errors from Sora or network issues, and improved logging for disconnect events. [[1]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebR72-R75) [[2]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebR91) [[3]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebR207) [[4]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebL217-L224)
* [`Sora/URLSessionWebSocketChannel.swift`](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebL100-R108): Enhanced logging for sending text and binary messages, and improved error logging when message sending fails. [[1]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebL100-R108) [[2]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebL118-R124)
* [`Sora/URLSessionWebSocketChannel.swift`](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebL161-R170): Improved error handling and logging for message reception failures, ensuring that higher-level error detection occurs in the `didCompleteWithError` method. [[1]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebL161-R170) [[2]](diffhunk://#diff-190097c879b90fee6c7551a319562b10c3325ebe06582c24fd3b820bc677e8ebR278-R286)

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L14-R32): Updated the change log to reflect the improvements in WebSocket disconnection handling and the addition of new encoding parameters for simulcast video.

### Code comments:

* [`Sora/SignalingChannel.swift`](diffhunk://#diff-f4494789b0911d145a23fa2b87c5525a222dac858458a06cd4af8d12289a5421L149-R150): Updated comments to clarify the behavior of the `onDisconnectWithError` handler for WebSocket disconnections.