### PR TITLE
multistreamEnabled を非推奨としてマークする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,9 +21,8 @@
   - 結果、connect メッセージには Configration.multistreamEnabled に指定した値が送信される
   - 今後は Configration.role に .sendrecv を指定している場合または Configration.spotlightEnabled に .enabled を指定している場合に Confgration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
-- [UPDATE] multistreamEnabled を非推奨扱いにする
-  - `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
-  - ドキュメントコメントに非推奨扱いの旨を追加する
+- [UPDATE] multistreamEnabled を非推奨にする
+  - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
   - @zztkm
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   - Configuration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除
   - Configuration.spotlightEnabled に .enabled を指定している場合に multistream を true に更新する処理を削除
   - 結果、connect メッセージには Configuration.multistreamEnabled に指定した値が送信される
-  - 今後は Configuration.role に .sendrecv を指定している場合または Configuration.spotlightEnabled に .enabled を指定している場合に Confgration.multistreamEnabled に false を指定すると接続エラーになる
+  - 今後は Configuration.role に .sendrecv を指定している場合または Configuration.spotlightEnabled に .enabled を指定している場合に Configuration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
 - [UPDATE] multistreamEnabled を非推奨にする
   - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@
   - 結果、connect メッセージには Configuration.multistreamEnabled に指定した値が送信される
   - 今後は Configuration.role に .sendrecv を指定している場合または Configuration.spotlightEnabled に .enabled を指定している場合に Configuration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
-- [UPDATE] multistreamEnabled を非推奨にする
+- [UPDATE] `Configuration.multistreamEnabled` を非推奨にする
   - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
   - @zztkm
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,10 +16,10 @@
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
 - [CHANGE] connect メッセージの `multistream` を true 固定で送信する処理を削除する破壊的変更
-  - Configration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除
-  - Configration.spotlightEnabled に .enabled を指定している場合に multistream を true に更新する処理を削除
-  - 結果、connect メッセージには Configration.multistreamEnabled に指定した値が送信される
-  - 今後は Configration.role に .sendrecv を指定している場合または Configration.spotlightEnabled に .enabled を指定している場合に Confgration.multistreamEnabled に false を指定すると接続エラーになる
+  - Configuration.role に .sendrecv を指定している場合に multistream を true に更新する処理を削除
+  - Configuration.spotlightEnabled に .enabled を指定している場合に multistream を true に更新する処理を削除
+  - 結果、connect メッセージには Configuration.multistreamEnabled に指定した値が送信される
+  - 今後は Configuration.role に .sendrecv を指定している場合または Configuration.spotlightEnabled に .enabled を指定している場合に Confgration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
 - [UPDATE] multistreamEnabled を非推奨にする
   - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
@@ -1035,7 +1035,7 @@
   - `SignalingSnapshotMessage`
   - `SignalingUpdateOfferMessage`
   - `Snapshot`
-  - `WebRTCConfiuration`
+  - `WebRTCConfiguration`
   - `WebRTCInfo`
   - @szktty
 - [ADD] 次の列挙体を追加する

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -81,9 +81,13 @@ public struct Configuration {
   public var role: Role
 
   /// マルチストリームの可否
-  ///
-  /// レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します
-  /// そのため、multistreamEnabled の使用は非推奨です
+  @available(
+    *, deprecated,
+    message: """
+      レガシーストリーム機能は 2025 年 6 月リリースの Sora にて廃止します。そのため multistreamEnabled の使用は非推奨です。
+      このプロパティは 2027 年中に廃止予定です。
+      """
+  )
   public var multistreamEnabled: Bool?
 
   /// :nodoc:


### PR DESCRIPTION
(元の CHANGES を修正したもの)
- [UPDATE] multistreamEnabled を非推奨にする
  - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
