### PR TITLE
onDisconnect: ((SoraCloseEvent) -> Void)) を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
   - @zztkm
 - [UPDATE] WebRTCConfigration.swift を WebRTCConfiguration.swift にリネームする
   - @zztkm
+- [UPDATE] Sora との接続を終了した際のイベント情報を表す、SoraCloseEvent を追加する
+  - @zztkm
 - [UPDATE] `MediaChannelHandlers` に `onDisconnect: ((SoraCloseEvent) -> Void)?` を追加する
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,12 +17,17 @@
   - 結果、connect メッセージには Configuration.multistreamEnabled に指定した値が送信される
   - 今後は Configuration.role に .sendrecv を指定している場合または Configuration.spotlightEnabled に .enabled を指定している場合に Configuration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
+- [CHANGE] `MediaCHannelHandlers` の `onDisconnect: ((Error?) -> Void)?` を `onDisconnectLegacy` という名前に変更し、非推奨にする
+  - `onDisconnect: ((SoraCloseEvent) -> Void)?` に移行するため、名前を変更した
+  - @zztkm
 - [UPDATE] WebRTC m132.6834.5.7 に上げる
   - @zztkm
 - [UPDATE] `Configuration.multistreamEnabled` を非推奨にする
   - 合わせて `Configuration` のイニシャライザの multistreamEnabled をオプション引数にし、デフォルト値を nil に変更
   - @zztkm
 - [UPDATE] WebRTCConfigration.swift を WebRTCConfiguration.swift にリネームする
+  - @zztkm
+- [UPDATE] `MediaChannelHandlers` に `onDisconnect: ((SoraCloseEvent) -> Void)?` を追加する
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
   - 結果、connect メッセージには Configuration.multistreamEnabled に指定した値が送信される
   - 今後は Configuration.role に .sendrecv を指定している場合または Configuration.spotlightEnabled に .enabled を指定している場合に Configuration.multistreamEnabled に false を指定すると接続エラーになる
   - @zztkm
-- [CHANGE] `MediaCHannelHandlers` の `onDisconnect: ((Error?) -> Void)?` を `onDisconnectLegacy` という名前に変更し、非推奨にする
+- [CHANGE] `MediaChannelHandlers` の `onDisconnect: ((Error?) -> Void)?` を `onDisconnectLegacy` という名前に変更し、非推奨にする
   - `onDisconnect: ((SoraCloseEvent) -> Void)?` に移行するため、名前を変更した
   - @zztkm
 - [UPDATE] WebRTC m132.6834.5.7 に上げる

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -25,12 +25,12 @@ public final class MediaChannelHandlers {
   @available(
     *, deprecated,
     message:
-      "onDisconnect: ((SoraCloseEvent) -> Void)? に移行してください。この onDisconnect: ((Error?) -> Void)? は、2027 年中に削除予定です。"
+      "onDisconnect: ((SoraCloseEvent) -> Void)? に移行してください。onDisconnectLegacy: ((Error?) -> Void)? は、2027 年中に削除予定です。"
   )
-  public var onDisconnect: ((Error?) -> Void)?
+  public var onDisconnectLegacy: ((Error?) -> Void)?
 
   /// 接続解除時に呼ばれるクロージャー
-  public var onClose: ((SoraCloseEvent) -> Void)?
+  public var onDisconnect: ((SoraCloseEvent) -> Void)?
 
   /// ストリームが追加されたときに呼ばれるクロージャー
   public var onAddStream: ((MediaStream) -> Void)?
@@ -412,8 +412,8 @@ public final class MediaChannel {
       state = .disconnected
 
       Logger.debug(type: .mediaChannel, message: "call onDisconnect")
-      internalHandlers.onDisconnect?(error)
-      handlers.onDisconnect?(error)
+      internalHandlers.onDisconnectLegacy?(error)
+      handlers.onDisconnectLegacy?(error)
     }
   }
 

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -426,7 +426,8 @@ public final class MediaChannel {
         if let soraError = error as? SoraError {
           switch soraError {
           case .webSocketClosed(let code, let reason):
-            return SoraCloseEvent.ok(code: code, reason: reason)
+            // 基本的に reason が nil なるケースはないはずだが、nil の場合は空文字列とする
+            return SoraCloseEvent.ok(code: code.intValue(), reason: reason ?? "")
           default:
             return SoraCloseEvent.error(error)
           }

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -414,6 +414,11 @@ public final class MediaChannel {
       Logger.debug(type: .mediaChannel, message: "call onDisconnect")
       internalHandlers.onDisconnectLegacy?(error)
       handlers.onDisconnectLegacy?(error)
+      if let error {
+        handlers.onDisconnect?(SoraCloseEvent.error(error))
+      } else {
+        handlers.onDisconnect?(SoraCloseEvent.ok(code: 1000, reason: "NO-ERROR"))
+      }
     }
   }
 

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -388,7 +388,7 @@ public final class MediaChannel {
     internalDisconnect(error: error, reason: .user)
   }
 
-  func internalDisconnect(error: Error?, reason: DisconnectReason, ) {
+  func internalDisconnect(error: Error?, reason: DisconnectReason) {
     switch state {
     case .disconnecting, .disconnected:
       break

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -22,7 +22,15 @@ public final class MediaChannelHandlers {
   public var onConnect: ((Error?) -> Void)?
 
   /// 接続解除時に呼ばれるクロージャー
+  @available(
+    *, deprecated,
+    message:
+      "onDisconnect: ((SoraCloseEvent) -> Void)? に移行してください。この onDisconnect: ((Error?) -> Void)? は、2027 年中に削除予定です。"
+  )
   public var onDisconnect: ((Error?) -> Void)?
+
+  /// 接続解除時に呼ばれるクロージャー
+  public var onDisconnect: ((SoraCloseEvent) -> Void)?
 
   /// ストリームが追加されたときに呼ばれるクロージャー
   public var onAddStream: ((MediaStream) -> Void)?

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -1,6 +1,21 @@
 import Foundation
 import WebRTC
 
+/// SoraCloseEvent は、Sora の接続が切断された際のイベント情報を表します。
+///
+/// 接続が正常に切断された場合は、`.ok(code, reason)` ケースが使用され、
+/// 異常な切断やエラー発生時は、`.error(Error)` ケースが使用されます。
+public enum SoraCloseEvent {
+  /// 正常な接続切断を示します。
+  /// - Parameters:
+  ///   - code: 接続切断時に返されるコード。例えば、WebSocket の標準切断コード（例: 1000 等）など。
+  ///   - reason: 接続が正常に切断された理由の説明文字列。
+  case ok(code: Int, reason: String)
+  /// 異常な切断またはエラーが発生して切断した場合に利用されるケースです。
+  /// - Parameter error: エラー情報。
+  case error(Error)
+}
+
 /// メディアチャネルのイベントハンドラです。
 public final class MediaChannelHandlers {
   /// 接続成功時に呼ばれるクロージャー

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -30,7 +30,7 @@ public final class MediaChannelHandlers {
   public var onDisconnect: ((Error?) -> Void)?
 
   /// 接続解除時に呼ばれるクロージャー
-  public var onDisconnect: ((SoraCloseEvent) -> Void)?
+  public var onClose: ((SoraCloseEvent) -> Void)?
 
   /// ストリームが追加されたときに呼ばれるクロージャー
   public var onAddStream: ((MediaStream) -> Void)?

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -195,7 +195,7 @@ public enum SimulcastRid {
 public enum SpotlightRid {
   /**
      SpotlightRid が設定されていない状態
-
+  
      変数の型を SpotlightRid? にした場合、 .none が Optional.none と SpotlightRid.none の
      どちらを指しているか分かりにくいという問題がありました。
      この問題を解決するため、変数に値が設定されていない状態を表す .unspecified を定義するとともに、

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -130,7 +130,7 @@ public final class Sora {
     ) -> Void
   ) -> ConnectionTask {
     let mediaChan = MediaChannel(manager: self, configuration: configuration)
-    mediaChan.internalHandlers.onDisconnect = { [weak self, weak mediaChan] error in
+    mediaChan.internalHandlers.onDisconnectLegacy = { [weak self, weak mediaChan] error in
       guard let weakSelf = self else {
         return
       }

--- a/Sora/SoraError.swift
+++ b/Sora/SoraError.swift
@@ -12,7 +12,10 @@ public enum SoraError: Error {
   /// 何らかの処理の実行中で、指定された処理を実行できないことを示します。
   case connectionBusy(reason: String)
 
-  /// ``WebSocketChannel`` が正常ではない状態で接続解除されたことを示します。
+  /// ``WebSocketChannel`` が接続解除されたことを示します。
+  /// 導入当初は Sora から受信したクローズフレームのステータスコードが 1000 以外のときにこの Error を返していたが
+  /// 2025.2.0 から、ステータスコードが 1000 のときも onDisconnect に切断理由を返すためにこの Error を使うようになった
+  /// また、この Error は onDisconnect では Error ではなく、SoraCloseEvent.ok(code, reason) としてユーザーに通知される
   case webSocketClosed(statusCode: WebSocketStatusCode, reason: String?)
 
   /// ``WebSocketChannel`` で発生したエラー


### PR DESCRIPTION
- [CHANGE] `MediaCHannelHandlers` の `onDisconnect: ((Error?) -> Void)?` を `onDisconnectLegacy` という名前に変更し、非推奨にする
  - `onDisconnect: ((SoraCloseEvent) -> Void)?` に移行するため、名前を変更した
- [UPDATE] Sora との接続を終了した際のイベント情報を表す、SoraCloseEvent を追加する
- [UPDATE] `MediaChannelHandlers` に `onDisconnect: ((SoraCloseEvent) -> Void)?` を追加する

---

Copilo Summary

This pull request includes changes to the `Sora` project to improve the handling of disconnection events and update some deprecated methods. The most important changes include the introduction of a new `SoraCloseEvent` enum, deprecation of the old `onDisconnect` handler, and updates to the error handling logic.

### Improvements to disconnection handling:

* [`Sora/MediaChannel.swift`](diffhunk://#diff-e404538b29ed73066b5a374feb2291aa34afbb1dde9de97ce45e96fa9c4af027R4-R33): Introduced the `SoraCloseEvent` enum to represent disconnection events, with cases for normal disconnection (`.ok`) and errors (`.error`).
* [`Sora/MediaChannel.swift`](diffhunk://#diff-e404538b29ed73066b5a374feb2291aa34afbb1dde9de97ce45e96fa9c4af027R4-R33): Deprecated the `onDisconnect: ((Error?) -> Void)?` handler and replaced it with `onDisconnect: ((SoraCloseEvent) -> Void)?`. Added a new `onDisconnectLegacy` handler for backward compatibility.
* [`Sora/MediaChannel.swift`](diffhunk://#diff-e404538b29ed73066b5a374feb2291aa34afbb1dde9de97ce45e96fa9c4af027L392-R439): Updated the `internalDisconnect` method to generate `SoraCloseEvent` based on the error and call the appropriate disconnection handlers.

### Updates to error handling:

* [`Sora/SoraError.swift`](diffhunk://#diff-bcaf1e870c6f676dfd34722813f4a49465c240d0b8f66f23d7f60385e2070c24L15-R18): Modified the `webSocketClosed` error to include status code 1000 and updated the documentation to reflect the changes in how disconnection reasons are handled.

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R20-R33): Documented the deprecation of the old `onDisconnect` handler and the introduction of the new `SoraCloseEvent` enum and `onDisconnect` handler.