### PR TITLE
Xcode バージョンを 16.3, iOS SDK を 18.4 にアップデートする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_16.2.app
-      XCODE_SDK: iphoneos18.2
+      XCODE: /Applications/Xcode_16.3.app
+      XCODE_SDK: iphoneos18.4
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@
   - @zztkm
 - [UPDATE] フォーマッターとリンターの実行を Makefile に移行したため、不要になった lint-format.sh を削除
   - @zztkm
+- [UPDATE] GitHub Actions のビルド環境を更新する
+  - Xcode の version を 16.3 に変更
+  - SDK を iOS 18.4 に変更
+  - @zztkm
 - [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
   - lint-format.sh で実行していたコマンドを個別に実行できるようにした
   - @zztkm

--- a/Sora/Signaling.swift
+++ b/Sora/Signaling.swift
@@ -195,7 +195,7 @@ public enum SimulcastRid {
 public enum SpotlightRid {
   /**
      SpotlightRid が設定されていない状態
-
+  
      変数の型を SpotlightRid? にした場合、 .none が Optional.none と SpotlightRid.none の
      どちらを指しているか分かりにくいという問題がありました。
      この問題を解決するため、変数に値が設定されていない状態を表す .unspecified を定義するとともに、


### PR DESCRIPTION
- [UPDATE] GitHub Actions のビルド環境を更新する
  - Xcode の version を 16.3 に変更
  - SDK を iOS 18.4 に変更

---

This pull request includes updates to the GitHub Actions build environment and documentation changes to reflect these updates.

Updates to GitHub Actions build environment:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L16-R17): Updated the Xcode version to 16.3 and the SDK to iOS 18.4.

Documentation changes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R56-R59): Added an entry to document the update of the GitHub Actions build environment, including the Xcode version change to 16.3 and the SDK change to iOS 18.4.