### PR TITLE
DataChannel Signaling の type: close のデータ構造を定義

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@
   - @zztkm
 - [ADD] Sora から DataChannel シグナリングを切断する際に "type": "close" メッセージを受信する機能を追加する
   - DataChannel シグナリングが有効、かつ ignore_disconnect_websocket が true、かつ Sora の設定で data_channel_signaling_close_message が有効な場合に受信することが可能
+  - "type": "close" に対応するため、 `Signaling` のケースに `close` を追加した
+    - `close` の associated value の型である `SignalingClose` 構造体を追加した
+  - `SoraError` に DataChannel シグナリングで "type": "close" を受信して接続が解除されたことを表すケースである `dataChannelClosed` を追加した
   - @zztkm
 - [FIX] Sora から切断された場合の切断処理を修正し適切なエラーを ``MediaChannelHandlers.onDisconnect`` で受け取ることができるようにする
   - Sora iOS SDK 2025.1.1 までは Sora から Close Frame を受け取ったり、ネットワークエラーが起きたりしても、WebSocket メッセージ受信失敗に起因する ``SoraError.webSocketError`` しか受信できなかったが、以下の内容を受信できるようになった

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@
   - @zztkm
 - [ADD] サイマルキャストの映像のエンコーディングパラメーター `scaleResolutionDownTo` を追加する
   - @zztkm
+- [ADD] Sora から DataChannel シグナリングを切断する際に "type": "close" メッセージを受信する機能を追加する
+  - DataChannel シグナリングが有効、かつ ignore_disconnect_websocket が true、かつ Sora の設定で data_channel_signaling_close_message が有効な場合に受信することが可能
+  - @zztkm
 - [FIX] Sora から切断された場合の切断処理を修正し適切なエラーを ``MediaChannelHandlers.onDisconnect`` で受け取ることができるようにする
   - Sora iOS SDK 2025.1.1 までは Sora から Close Frame を受け取ったり、ネットワークエラーが起きたりしても、WebSocket メッセージ受信失敗に起因する ``SoraError.webSocketError`` しか受信できなかったが、以下の内容を受信できるようになった
     - Sora から Close Frame を受け取った場合のステータスコードと理由

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -428,6 +428,8 @@ public final class MediaChannel {
           case .webSocketClosed(let code, let reason):
             // 基本的に reason が nil なるケースはないはずだが、nil の場合は空文字列とする
             return SoraCloseEvent.ok(code: code.intValue(), reason: reason ?? "")
+          case .dataChannelClosed(let code, let reason):
+            return SoraCloseEvent.ok(code: code, reason: reason)
           default:
             return SoraCloseEvent.error(error)
           }

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -416,7 +416,7 @@ public final class MediaChannel {
       handlers.onDisconnectLegacy?(error)
 
       // クロージャを用いて、エラーの内容に応じた SoraCloseEvent を生成
-      // error が nil の場合はクライアントからの正常終了として .ok にする
+      // error が nil の場合はクライアントからの正常終了 or DataChannel のみのシグナリング利用時の正常終了として .ok にする
       // error が SoraError の場合はケースに応じて .ok と .error を切り替える
       // error が SoraError の場合はクライアントが disconnect に渡した error のため、そのまま .error とする
       let disconnectEvent: SoraCloseEvent = {

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -994,7 +994,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       // 処理は不要
       break
     case .close(let close):
-      Logger.debug(type: .peerChannel, message: "close received: \(close.code), \(close.reason)")
+      // dataChannelSignalngClose に格納した値は basicDisconnect で利用される
       dataChannelSignalngClose = (code: close.code, reason: close.reason)
     default:
       Logger.error(
@@ -1053,8 +1053,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     signalingChannel.disconnect(error: error, reason: reason)
 
     Logger.debug(type: .peerChannel, message: "call onDisconnect")
-    /// dataChannelSignalngClose が nil でない、かつ reason が DisconnectReason.dataChannelClosed の場合は
-    /// SoraError.dataChannelClosed でラップして onDisconnect にわたす
+    /// DataChannel がクローズされ (reason == .dataChannelClosed)、
+    /// かつ事前に Sora から "close" メッセージを受信していた場合 (dataChannelSignalngClose != nil)、
+    /// MediaChannel にそのメッセージ内容を dataChannelClosed として通知する
     if let dataChannelSignalngClose = dataChannelSignalngClose,
       case .dataChannelClosed = reason
     {

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1054,7 +1054,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
     Logger.debug(type: .peerChannel, message: "call onDisconnect")
     /// DataChannel がクローズされ (reason == .dataChannelClosed)、
-    /// かつ事前に Sora から "close" メッセージを受信していた場合 (dataChannelSignalngClose != nil)、
+    /// かつ事前に Sora から "close" メッセージを受信していた場合 (dataChannelSignalingClose != nil)、
     /// MediaChannel にそのメッセージ内容を dataChannelClosed として通知する
     if let dataChannelSignalingClose = dataChannelSignalingClose,
       case .dataChannelClosed = reason

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1066,6 +1066,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     } else {
       internalHandlers.onDisconnect?(error, reason)
     }
+    // disconnect したあとは基本的に PeerChannel を使い回さないはずだが、一応 nil にしておく
+    dataChannelSignalingClose = nil
 
     if onConnect != nil {
       Logger.debug(type: .peerChannel, message: "call connect(handler:)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -994,7 +994,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       // 処理は不要
       break
     case .close(let close):
-      // dataChannelSignalngClose に格納した値は basicDisconnect で利用される
+      // dataChannelSignalingClose に格納した値は basicDisconnect で利用される
       dataChannelSignalingClose = (code: close.code, reason: close.reason)
     default:
       Logger.error(

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -147,7 +147,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
   private var connectedAtLeastOnce: Bool = false
 
   /// DataChannel シグナリングで type: close メッセージを受信したときにメッセージ内容を保存するための変数
-  private var dataChannelSignalngClose: (code: Int, reason: String)?
+  private var dataChannelSignalingClose: (code: Int, reason: String)?
 
   // type: redirect のために SDP を保存しておく
   // 値が設定されている場合2回目の type: connect メッセージ送信とみなし、 redirect 中であると判断する
@@ -995,7 +995,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       break
     case .close(let close):
       // dataChannelSignalngClose に格納した値は basicDisconnect で利用される
-      dataChannelSignalngClose = (code: close.code, reason: close.reason)
+      dataChannelSignalingClose = (code: close.code, reason: close.reason)
     default:
       Logger.error(
         type: .peerChannel, message: "unexpected signaling type => \(signaling.typeName())")
@@ -1056,12 +1056,12 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     /// DataChannel がクローズされ (reason == .dataChannelClosed)、
     /// かつ事前に Sora から "close" メッセージを受信していた場合 (dataChannelSignalngClose != nil)、
     /// MediaChannel にそのメッセージ内容を dataChannelClosed として通知する
-    if let dataChannelSignalngClose = dataChannelSignalngClose,
+    if let dataChannelSignalingClose = dataChannelSignalingClose,
       case .dataChannelClosed = reason
     {
       internalHandlers.onDisconnect?(
         SoraError.dataChannelClosed(
-          statusCode: dataChannelSignalngClose.code, reason: dataChannelSignalngClose.reason),
+          statusCode: dataChannelSignalingClose.code, reason: dataChannelSignalingClose.reason),
         reason)
     } else {
       internalHandlers.onDisconnect?(error, reason)

--- a/Sora/SoraError.swift
+++ b/Sora/SoraError.swift
@@ -39,7 +39,11 @@ public enum SoraError: Error {
   /// メッセージング機能のエラー
   case messagingError(reason: String)
 
-  /// DataChannel 経由のシグナリングで type: close を受け取った場合の切断を示します
+  /// DataChannel 経由のシグナリングで type: close を受信し、接続が解除されたことを示します。
+  ///
+  /// ラベルの説明
+  /// - statusCode: ステータスコード
+  /// - reason: 切断理由
   case dataChannelClosed(statusCode: Int, reason: String)
 }
 

--- a/Sora/SoraError.swift
+++ b/Sora/SoraError.swift
@@ -38,6 +38,9 @@ public enum SoraError: Error {
 
   /// メッセージング機能のエラー
   case messagingError(reason: String)
+
+  /// DataChannel 経由のシグナリングで type: close を受け取った場合の切断を示します
+  case dataChannelClosed(statusCode: Int, reason: String)
 }
 
 /// :nodoc:
@@ -73,6 +76,8 @@ extension SoraError: LocalizedError {
       return "Camera error: \(reason)"
     case .messagingError(let reason):
       return "Messaging error: \(reason)"
+    case .dataChannelClosed(let statusCode, let reason):
+      return "DataChannel is closed (\(statusCode) \(reason))"
     }
   }
 }

--- a/Sora/SoraError.swift
+++ b/Sora/SoraError.swift
@@ -40,8 +40,6 @@ public enum SoraError: Error {
   case messagingError(reason: String)
 
   /// DataChannel 経由のシグナリングで type: close を受信し、接続が解除されたことを示します。
-  ///
-  /// ラベルの説明
   /// - statusCode: ステータスコード
   /// - reason: 切断理由
   case dataChannelClosed(statusCode: Int, reason: String)


### PR DESCRIPTION
- [ADD] Sora から DataChannel シグナリングを切断する際に "type": "close" メッセージを受信する機能を追加する
  - DataChannel シグナリングが有効、かつ ignore_disconnect_websocket が true、かつ Sora の設定で data_channel_signaling_close_message が有効な場合に受信することが可能

Copilot Summary
---

This pull request introduces a new feature for handling "close" messages from DataChannel signaling in the Sora SDK, along with some related bug fixes and improvements. The most important changes include updates to the signaling handling, modifications to the `MediaChannel` and `PeerChannel` classes, and enhancements to error handling.

### New Feature: DataChannel "close" Message Handling
* Added functionality to receive and handle "type": "close" messages from DataChannel signaling in specific configurations. (`CHANGES.md` [CHANGES.mdR36-R38](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R36-R38))
* Introduced a new case `.close` in the `Signaling` enum to represent "close" signaling messages. (`Sora/Signaling.swift` [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R135-R138) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R182-R183)
* Defined a new `SignalingClose` struct to store the status code and reason for "close" messages. (`Sora/Signaling.swift` [[1]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R524-R532) [[2]](diffhunk://#diff-bbaf8d62f8925be570bb0b4c1b60e5e6b4de89de86c827d196cc0e9d257a4505R1375-R1388)

### Modifications to `MediaChannel` and `PeerChannel` Classes
* Added a new case `.dataChannelClosed` in the `MediaChannel` class to handle DataChannel closure events. (`Sora/MediaChannel.swift` [Sora/MediaChannel.swiftR431-R432](diffhunk://#diff-e404538b29ed73066b5a374feb2291aa34afbb1dde9de97ce45e96fa9c4af027R431-R432))
* Introduced a variable in the `PeerChannel` class to store the message content when a "close" message is received via DataChannel signaling. (`Sora/PeerChannel.swift` [[1]](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457R149-R151) [[2]](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457R996-R998)
* Updated the `onDisconnect` method in the `PeerChannel` class to notify `MediaChannel` of DataChannel closure events when a "close" message has been received. (`Sora/PeerChannel.swift` [Sora/PeerChannel.swiftR1056-R1068](diffhunk://#diff-15b81a7bc3777daaf0b8640a8ff1265ee5d3e5aad60f3928b58b50ec46817457R1056-R1068))

### Enhancements to Error Handling
* Added a new case `.dataChannelClosed` to the `SoraError` enum to represent disconnections due to DataChannel "close" messages. (`Sora/SoraError.swift` [Sora/SoraError.swiftR41-R43](diffhunk://#diff-bcaf1e870c6f676dfd34722813f4a49465c240d0b8f66f23d7f60385e2070c24R41-R43))
* Updated the `LocalizedError` extension to provide a localized description for the new `.dataChannelClosed` error case. (`Sora/SoraError.swift` [Sora/SoraError.swiftR79-R80](diffhunk://#diff-bcaf1e870c6f676dfd34722813f4a49465c240d0b8f66f23d7f60385e2070c24R79-R80))