### PR TITLE
canary.py のバージョン更新処理でのインデント修正とファイル書き込み時のエンコーディング指定を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,11 @@
   - @zztkm
 - [UPDATE] CocoaPods の廃止対応のため、canary.py から Sora.podspec の更新処理を削除する
   - @zztkm
+- [UPDATE] フォーマッターの設定に合わせて canary.py で PackageInfo.swift に書き込む際のスペースを 4 から 2 に変更する
+  - @zztkm
+- [UPDATE] canary.py でファイルの読み書きを行う際の encoding を明示的に utf-8 に設定する
+  - Windows 環境で canary.py を実行した際に、予期せぬ文字化けが発生してしまうため修正を行った
+  - @zztkm
 - [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
   - lint-format.sh で実行していたコマンドを個別に実行できるようにした
 

--- a/canary.py
+++ b/canary.py
@@ -44,9 +44,7 @@ def update_packageinfo_version(packageinfo_content):
                     new_version = f"{major_minor_patch}-canary.{canary_number + 1}"
 
                 # PackageInfoのバージョン行を更新
-                updated_content.append(
-                    f'    public static let version = "{new_version}"'
-                )
+                updated_content.append(f'  public static let version = "{new_version}"')
                 sdk_version_updated = True
             else:
                 updated_content.append(line)
@@ -72,7 +70,7 @@ def write_file(filename, updated_content, dry_run):
         print(f"Dry run: The following changes would be written to {filename}:")
         print("\n".join(updated_content))
     else:
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             file.write("\n".join(updated_content) + "\n")
         print(f"{filename} updated.")
 
@@ -136,7 +134,7 @@ def main():
     args = parser.parse_args()
 
     # PackageInfoファイルを読み込んでバージョンを更新
-    with open(PACKAGEINFO_FILE, "r") as file:
+    with open(PACKAGEINFO_FILE, "r", encoding="utf-8") as file:
         packageinfo_content = file.readlines()
     updated_packageinfo_content, new_version = update_packageinfo_version(packageinfo_content)
     write_file(PACKAGEINFO_FILE, updated_packageinfo_content, args.dry_run)


### PR DESCRIPTION
- [UPDATE] フォーマッターの設定に合わせて canary.py で PackageInfo.swift に書き込む際のスペースを 4 から 2 に変更する
- [UPDATE] canary.py でファイルの読み書きを行う際の encoding を明示的に utf-8 に設定する
  - Windows 環境で canary.py を実行した際に、予期せぬ文字化けが発生してしまうため修正を行った
