### PR TITLE
scaleResolutionDownTo の値のコピー方法を変更する

### DIFF
--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -1349,7 +1349,7 @@ extension RTCRtpSender {
     Logger.debug(
       type: .peerChannel, message: "update offer encodings for sender => \(senderId)")
 
-    // paramaters はアクセスのたびにコピーされてしまうので、すべての parameters をセットし直す
+    // parameters はアクセスのたびにコピーされてしまうので、すべての parameters をセットし直す
     let newParameters = parameters  // コピーされる
     for oldEncoding in newParameters.encodings {
       Logger.debug(
@@ -1387,8 +1387,7 @@ extension RTCRtpSender {
           Logger.debug(
             type: .peerChannel,
             message: "scaleResolutionDownTo: \(value.maxWidth)x\(value.maxHeight)")
-          oldEncoding.scaleResolutionDownTo?.maxWidth = value.maxWidth
-          oldEncoding.scaleResolutionDownTo?.maxHeight = value.maxHeight
+          oldEncoding.scaleResolutionDownTo = value
         }
 
         if let value = encoding.scalabilityMode {


### PR DESCRIPTION
リリース前の機能についての修正であり CHANGES.md には追記なしのため、ここに変更内容をまとめます。

- サイマルキャストの `scaleResolutionDownTo` の値のコピー方法を修正する
  - 個別のプロパティ（maxWidth、maxHeight）を設定する方法から、オブジェクト全体を代入する方法に変更
  - 同時に RTCRtpSender のエクステンションコメント内のタイポ（`paramaters` → `parameters`）を修正


---

[対応済]
libwebrtc のパッチも修正します。

`RTCResolutionRestriction` をコピー可能なオブジェクトに変更する必要があります。

注意：この PR を通す前に、https://github.com/shiguredo-webrtc-build/webrtc-build/pull/103 をマージして、m138 の最新版をリリースする必要があります。