### PR TITLE
github actions ビルドの ios バージョンを更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
-      XCODE: /Applications/Xcode_16.4.app
-      XCODE_SDK: iphoneos18.5
+      XCODE: /Applications/Xcode_26.2.app
+      XCODE_SDK: iphoneos26.2
     steps:
     - uses: actions/checkout@v6
     - name: Select Xcode Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,11 @@
 
 ### misc
 
+- [UPDATE] GitHub Actions のビルド環境を更新する
+  - macOS の version を 26 に変更
+  - Xcode の version を 26.2 に変更
+  - SDK を iOS 26.2 に変更
+  - @t-miya
 - [UPDATE] SwiftLint を 0.63.0 に上げる
   - @zztkm
 - [UPDATE] `Claude Assistant` の `claude-response` を `ubuntu-slim` に移行する
@@ -97,11 +102,6 @@
 - [ADD] `Package.swift` に `testTarget` を追加する
   - xcodebuild で test を実行するために target を追加
   - @zztkm
-- [FIX] GitHub Actions のビルド環境を更新する
-  - GitHub Actions でのビルドが通らなくなったため
-  - Xcode の version を 16.4 に変更
-  - SDK を iOS 18.5 に変更
-  - @t-miya
 
 ## 2025.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,11 @@
 - [ADD] `Package.swift` に `testTarget` を追加する
   - xcodebuild で test を実行するために target を追加
   - @zztkm
+- [FIX] GitHub Actions のビルド環境を更新する
+  - macOS 15 での利用中に `error: iOS 18.4 Platform Not Installed.` となってしまったため
+  - Xcode の version を 16.4 に変更
+  - SDK を iOS 18.5 に変更
+  - @t-miya
 
 ## 2025.2.0
 


### PR DESCRIPTION
26.2 に更新