### PR TITLE
Configure.initialCameraEnabled を追加、接続時のカメラ初期化を遅延できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 
 ## develop
 
-- [UPDATE] VideoHardMuteActor での映像ハードミュート解除時にカメラキャプチャ未生成なら生成するようにする
-  - `Configuration.initialCameraEnabled` により接続時にカメラ初期化が行われていない場合の処理
+- [UPDATE] VideoHardMuteActor での映像ハードミュート解除時にカメラキャプチャ未起動なら開始するようにする
+  - `Configuration.initialCameraEnabled` により接続時にカメラ初期化が行われていない場合の分岐
   - @t-miya
 - [UPDATE] libwebrtc m144.7559.2.1 に上げる
   - @t-miya

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] VideoHardMuteActor での映像ハードミュート解除時にカメラキャプチャ未生成なら生成するようにする
+  - `Configuration.initialCameraEnabled` により接続時にカメラ初期化が行われていない場合の処理
+  - @t-miya
 - [UPDATE] libwebrtc m144.7559.2.1 に上げる
   - @t-miya
 - [UPDATE] Statistics, StatisticsEntry をドキュメント対象として公開する
@@ -19,6 +22,9 @@
 - [UPDATE] Configuration.simulcastRid を非推奨にする
   - 移行先は `Configuration.simulcastRequestRid`
   - @zztkm
+- [ADD] Configuration に接続確立時にカメラ初期化を行わない設定 `initialCameraEnabled` を追加する
+  - 接続時に映像ハードミュートを行うために利用する
+  - @t-miya
 - [ADD] MediaChannel に音声ソフトミュートを設定する `setAudioSoftMute(_:)` を追加する
   - 送信ストリームの AudioTrack を取得し、MediaStream.audioEnabled を切り替える
     - デジタルサイレンスパケットが送られる状態となり、マイクからの音声は送出されない

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -139,7 +139,7 @@ public struct Configuration {
   ///
   /// `cameraSettings.isEnabled` が `true` の場合でも、このフラグが `false` であれば
   /// 接続時点ではカメラキャプチャを起動しません。
-  /// 後から `MediaChannel.setVideoHardMute(false)` などで必要に応じて開始できます。
+  /// 後から `MediaChannel.setVideoHardMute(false)` で必要に応じて開始できます。
   public var initialCameraEnabled: Bool = true
 
   /// サイマルキャストの可否。 `true` であればサイマルキャストを有効にします。

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -135,6 +135,13 @@ public struct Configuration {
   /// デフォルトは `true` です。
   public var audioEnabled: Bool = true
 
+  /// 接続確立時に端末カメラキャプチャを自動起動するかどうか。
+  ///
+  /// `cameraSettings.isEnabled` が `true` の場合でも、このフラグが `false` であれば
+  /// 接続時点ではカメラキャプチャを起動しません。
+  /// 後から `MediaChannel.setVideoHardMute(false)` などで必要に応じて開始できます。
+  public var initialCameraEnabled: Bool = true
+
   /// サイマルキャストの可否。 `true` であればサイマルキャストを有効にします。
   public var simulcastEnabled: Bool = false
 

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -754,10 +754,18 @@ public final class MediaChannel {
     if mute {
       // ソフトミュートによる黒塗りフレーム送出 -> ハードミュート有効化の順になるようにします
       senderStream.videoEnabled = false
-      try await Self.videoHardMuteActor.setMute(mute: true, senderStream: senderStream)
+      try await Self.videoHardMuteActor.setMute(
+        mute: true,
+        senderStream: senderStream,
+        cameraSettings: configuration.cameraSettings
+      )
     } else {
       // ハードミュート無効化 -> ソフトミュートによる黒塗りフレーム送出解除の順になるようにします
-      try await Self.videoHardMuteActor.setMute(mute: false, senderStream: senderStream)
+      try await Self.videoHardMuteActor.setMute(
+        mute: false,
+        senderStream: senderStream,
+        cameraSettings: configuration.cameraSettings
+      )
       senderStream.videoEnabled = true
     }
     Logger.debug(type: .mediaChannel, message: "setVideoHardMute mute=\(mute)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -482,7 +482,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     }
 
     // カメラの初期化
-    if configuration.videoEnabled, configuration.cameraSettings.isEnabled {
+    if configuration.videoEnabled, configuration.cameraSettings.isEnabled,
+      configuration.initialCameraEnabled
+    {
       initializeCameraVideoCapture(stream: stream)
     }
 

--- a/Sora/VideoMute.swift
+++ b/Sora/VideoMute.swift
@@ -141,7 +141,9 @@ actor VideoHardMuteActor {
         // CameraVideoCapturer.start はコールバック形式です
         let capturer = CameraVideoCapturer(device: device)
         capturer.stream = senderStream
-        capturer.start(format: format, frameRate: frameRate) { error in
+        // start 完了まで capturer を確実に生存させるためにクロージャ側でも保持します。
+        // start 成功時は CameraVideoCapturer.current がセットされ、以後はそちらが保持します。
+        capturer.start(format: format, frameRate: frameRate) { [capturer] error in
           if let error {
             continuation.resume(throwing: error)
           } else {

--- a/Sora/VideoMute.swift
+++ b/Sora/VideoMute.swift
@@ -5,8 +5,8 @@ import Foundation
 actor VideoHardMuteActor {
   // 処理実行中フラグ
   private var isProcessing = false
-  // カメラ操作のためのキャプチャラー
-  private var capturer: CameraVideoCapturer?
+  // ハードミュートで stop したキャプチャを解除時に restart するための保持キャプチャラー
+  private var storedCapturer: CameraVideoCapturer?
 
   /// ハードミュートを有効化/無効化します
   ///
@@ -32,7 +32,7 @@ actor VideoHardMuteActor {
       }
       try await stopCameraVideoCapture(currentCapturer)
       // ミュート無効化する際にキャプチャラーを使用するため保持しておきます
-      capturer = currentCapturer
+      storedCapturer = currentCapturer
       return
     }
 
@@ -41,8 +41,8 @@ actor VideoHardMuteActor {
     let currentCapturer = await currentCameraVideoCapturer()
     if currentCapturer != nil { return }
     // 前回停止時のキャプチャラーが保持できていれば restart、なければ start します
-    if let stored = capturer {
-      try await restartCameraVideoCapture(stored, senderStream: senderStream)
+    if let capturerForRestart = storedCapturer {
+      try await restartCameraVideoCapture(capturerForRestart, senderStream: senderStream)
       return
     }
     try await startCameraVideoCapture(cameraSettings: cameraSettings, senderStream: senderStream)

--- a/Sora/VideoMute.swift
+++ b/Sora/VideoMute.swift
@@ -40,7 +40,7 @@ actor VideoHardMuteActor {
     // 現在のキャプチャラーが取得できる場合は既に再開済みとして成功扱いにします
     let currentCapturer = await currentCameraVideoCapturer()
     if currentCapturer != nil { return }
-    // 前回停止時のキャプチャラーが保持できていれば restart、なければ新規に start します
+    // 前回停止時のキャプチャラーが保持できていれば restart、なければ start します
     if let stored = capturer {
       try await restartCameraVideoCapture(stored, senderStream: senderStream)
       return
@@ -111,7 +111,8 @@ actor VideoHardMuteActor {
         switch cameraSettings.position {
         case .front:
           guard let front = CameraVideoCapturer.front else {
-            continuation.resume(throwing: SoraError.cameraError(reason: "front camera is not found"))
+            continuation.resume(
+              throwing: SoraError.cameraError(reason: "front camera is not found"))
             return
           }
           capturer = front


### PR DESCRIPTION
## 背景
現状の実装ではカメラ有効の設定での開始時は必ずカメラキャプチャが生成されるため、カメラキャプチャの生成遅延により
開始時カメラミュートを行うことができない。
ちなみにカメラ無効で開始した場合は `MediaChannel.setVideHardMute` による解除をすることができない。

## 修正内容
接続設定に `initialCameraEnabled` を追加することにより、カメラキャプチャの生成を遅延できるようにする。
また、`VideoHardMuteActor. setMute(false)` でカメラキャプチャが未生成の場合は生成するようにする。