### PR TITLE
接続時にマイク入力を無効にできるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,13 @@
 
 ## develop
 
+- [UPDATE] PeerChannel.initializeAudioInput での音声入力初期化時にマイク入力をミュートするか設定するようにする
+  - `RTCAudioSession.setInitialMicrophoneMute` に `Configuration.initialMicrophoneEnabled` の否定値を渡す
+  - @t-miya
 - [UPDATE] libwebrtc m144.7559.2.2 に上げる
   - @t-miya
 - [UPDATE] VideoHardMuteActor での映像ハードミュート解除時にカメラキャプチャ未起動なら開始するようにする
   - `Configuration.initialCameraEnabled` により接続時にカメラ初期化が行われていない場合の分岐
-  - @t-miya
-- [UPDATE] libwebrtc m144.7559.2.1 に上げる
   - @t-miya
 - [UPDATE] Statistics, StatisticsEntry をドキュメント対象として公開する
   - `getStats` メソッドの返り値である `Statistics` のドキュメントを生成するため
@@ -24,6 +25,9 @@
 - [UPDATE] Configuration.simulcastRid を非推奨にする
   - 移行先は `Configuration.simulcastRequestRid`
   - @zztkm
+- [ADD] Configuration に接続確立時のマイク入力を有効にするか設定できる `initialMicrophoneEnabled` を追加する
+  - 接続時に音声ハードミュートを行うために利用する
+  - @t-miya
 - [ADD] Configuration に接続確立時にカメラ初期化を行わない設定 `initialCameraEnabled` を追加する
   - 接続時に映像ハードミュートを行うために利用する
   - @t-miya

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] libwebrtc m144.7559.2.2 に上げる
+  - @t-miya
 - [UPDATE] VideoHardMuteActor での映像ハードミュート解除時にカメラキャプチャ未起動なら開始するようにする
   - `Configuration.initialCameraEnabled` により接続時にカメラ初期化が行われていない場合の分岐
   - @t-miya

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let libwebrtcVersion = "m144.7559.2.1"
+let libwebrtcVersion = "m144.7559.2.2"
 
 let package = Package(
     name: "Sora",
@@ -21,7 +21,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo-webrtc-build/webrtc-build/releases/download/\(libwebrtcVersion)/WebRTC.xcframework.zip",
-            checksum: "610c342f3e8f6199e2b6672fd3e6102876cbd2a131470ef0077de7b3a895d011"
+            checksum: "5e13c05f4684b9c0478079a49c11225d9bcaea2bbb5e0b3abec2ad3bda91f56d"
         ),
         .target(
             name: "Sora",

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -142,6 +142,12 @@ public struct Configuration {
   /// 後から `MediaChannel.setVideoHardMute(false)` で必要に応じて開始できます。
   public var initialCameraEnabled: Bool = true
 
+  /// 接続確立時にマイクを有効にするかどうか。
+  ///
+  /// このフラグが `false` であれば接続時点ではマイク入力は無効となります。(ハードミュート相当)
+  /// 後から `MediaChannel.setAudioHardMute(false)` で必要に応じてマイクを有効にできます。
+  public var initialMicrophoneEnabled: Bool = true
+
   /// サイマルキャストの可否。 `true` であればサイマルキャストを有効にします。
   public var simulcastEnabled: Bool = false
 

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -511,7 +511,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       do {
         session.lockForConfiguration()
         defer { session.unlockForConfiguration() }
-        try session.setInitialMicrophoneMute(configuration.initialAudioHardMute)
+        try session.setInitialMicrophoneMute(configuration.initialMicrophoneEnabled)
       } catch {
         Logger.debug(
           type: .peerChannel,

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -508,16 +508,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
       // 初期状態でマイクをミュートするかを設定します。
       // 入力初期化後は変更できないため、 initializeInput の前に設定します。
-      do {
-        session.lockForConfiguration()
-        defer { session.unlockForConfiguration() }
-        try session.setInitialMicrophoneMute(configuration.initialMicrophoneEnabled)
-      } catch {
-        Logger.debug(
-          type: .peerChannel,
-          message:
-            "failed to setInitialMicrophoneMute => \(error.localizedDescription)"
-        )
+      let initialMicrophoneMute = !configuration.initialMicrophoneEnabled
+      if !session.setInitialMicrophoneMute(initialMicrophoneMute) {
+        Logger.debug(type: .peerChannel, message: "failed to setInitialMicrophoneMute")
       }
 
       // カテゴリをマイク用途のものに変更する

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -507,6 +507,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       let session = RTCAudioSession.sharedInstance()
 
       // 初期状態でマイクをミュートするかを設定します。
+      // setInitialMicrophoneMute はマイクミュートを有効にするか、initialMicrophoneEnabled は初期のマイクを有効にするか
+      // の設定のため、initialMicrophoneEnabled の否定値を渡します。
+      //
       // 入力初期化後は変更できないため、 initializeInput の前に設定します。
       let initialMicrophoneMute = !configuration.initialMicrophoneEnabled
       if !session.setInitialMicrophoneMute(initialMicrophoneMute) {

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -513,7 +513,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       // 入力初期化後は変更できないため、 initializeInput の前に設定します。
       let initialMicrophoneMute = !configuration.initialMicrophoneEnabled
       if !session.setInitialMicrophoneMute(initialMicrophoneMute) {
-        Logger.debug(type: .peerChannel, message: "failed to setInitialMicrophoneMute")
+        Logger.warn(type: .peerChannel, message: "failed to setInitialMicrophoneMute")
       }
 
       // カテゴリをマイク用途のものに変更する


### PR DESCRIPTION
音声ハードミュート相当の状態で接続できるようにする
- アプリ側から指定できるように `Configuration` に `initialMicrophoneEnabled` を追加する
- PeerChannel での音声初期化時に `RTCAudioSession.setInitialMicrophoneMute` にマイク入力を有効にするかの否定値を渡す