### PR TITLE
SwiftLintPlugins を 0.63.2 に更新する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,8 +104,6 @@
   - @t-miya
 - [UPDATE] SwiftLintPlugins を 0.63.2 に上げる
   - @zztkm
-- [UPDATE] SwiftLint を 0.63.0 に上げる
-  - @zztkm
 - [UPDATE] `Claude Assistant` の `claude-response` を `ubuntu-slim` に移行する
   - @zztkm
 - [UPDATE] jazzy の設定ファイルを更新する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,8 @@
   - Xcode の version を 26.2 に変更
   - SDK を iOS 26.2 に変更
   - @t-miya
+- [UPDATE] SwiftLintPlugins を 0.63.2 に上げる
+  - @zztkm
 - [UPDATE] SwiftLint を 0.63.0 に上げる
   - @zztkm
 - [UPDATE] `Claude Assistant` の `claude-response` を `ubuntu-slim` に移行する

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SimplyDanny/SwiftLintPlugins",
         "state": {
           "branch": null,
-          "revision": "707f7face5524fe918f82dd39c5c80cb3e591a44",
-          "version": "0.63.0"
+          "revision": "8a4640d14777685ba8f14e832373160498fbab92",
+          "version": "0.63.2"
         }
       }
     ]


### PR DESCRIPTION
## 変更内容
- Swift Package 依存の SwiftLintPlugins を 0.63.0 から 0.63.2 へ更新しました
- 変更は Package.resolved のみです

## 確認内容
- swift package update
- xcodebuild -scheme 'Sora' -sdk iphoneos26.1 -configuration Release -derivedDataPath build -destination 'generic/platform=iOS' clean build CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= PROVISIONING_PROFILE=
  - BUILD SUCCEEDED を確認
