### PR TITLE
RPC の id を Int に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,7 +80,6 @@
     - `ResetSpotlightRid`
     - `PutSignalingNotifyMetadata`
     - `PutSignalingNotifyMetadataItem`
-  - RPC の ID は `Int` として扱う
   - RPC エラー応答の詳細を表す `RPCErrorDetail` 構造体を追加する
   - RPC 成功応答を表す `RPCResponse<Result>` ジェネリック構造体を追加する
   - DataChannel 経由の RPC を扱う `RPCChannel` クラスを追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,8 +80,7 @@
     - `ResetSpotlightRid`
     - `PutSignalingNotifyMetadata`
     - `PutSignalingNotifyMetadataItem`
-  - RPC の ID を表す `RPCID` 列挙型を追加する
-    - `int(Int)` と `string(String)` の 2 つのケースをサポート
+  - RPC の ID は `Int` として扱う
   - RPC エラー応答の詳細を表す `RPCErrorDetail` 構造体を追加する
   - RPC 成功応答を表す `RPCResponse<Result>` ジェネリック構造体を追加する
   - DataChannel 経由の RPC を扱う `RPCChannel` クラスを追加する

--- a/Sora/RPC.swift
+++ b/Sora/RPC.swift
@@ -246,27 +246,16 @@ final class RPCChannel {
     pending.completion(result)
   }
 
-  static func parseResponseID(_ value: Any) throws -> Int {
+  private static func parseResponseID(_ value: Any) throws -> Int {
     if let intValue = value as? Int {
       return intValue
     }
-    guard let numberValue = value as? NSNumber else {
-      throw SoraError.rpcDecodingError(reason: "response id の型が不正です: \(type(of: value))")
+    if let numberValue = value as? NSNumber {
+      return numberValue.intValue
+    } else {
+      throw SoraError.rpcDecodingError(
+        reason: "response id は Int または NSNumber である必要があります: \(type(of: value))")
     }
-    if CFGetTypeID(numberValue) == CFBooleanGetTypeID() {
-      throw SoraError.rpcDecodingError(reason: "response id に Bool は利用できません")
-    }
-    guard !CFNumberIsFloatType(numberValue) else {
-      throw SoraError.rpcDecodingError(reason: "response id は整数のみ利用できます: \(numberValue)")
-    }
-    let int64Value = numberValue.int64Value
-    guard NSNumber(value: int64Value) == numberValue else {
-      throw SoraError.rpcDecodingError(reason: "response id が Int の範囲外です: \(numberValue)")
-    }
-    guard let intValue = Int(exactly: int64Value) else {
-      throw SoraError.rpcDecodingError(reason: "response id が Int の範囲外です: \(numberValue)")
-    }
-    return intValue
   }
 }
 

--- a/Sora/RPC.swift
+++ b/Sora/RPC.swift
@@ -1,37 +1,5 @@
 import Foundation
 
-/// RPC の ID を表す型。
-public enum RPCID: Hashable {
-  case int(Int)
-  case string(String)
-
-  init?(any value: Any) {
-    if let intValue = value as? Int {
-      self = .int(intValue)
-      return
-    }
-    // JSONSerialization は整数を NSNumber として返すことがあるためこちらも考慮する
-    if let numberValue = value as? NSNumber {
-      self = .int(numberValue.intValue)
-      return
-    }
-    if let stringValue = value as? String {
-      self = .string(stringValue)
-      return
-    }
-    return nil
-  }
-
-  var jsonValue: Any {
-    switch self {
-    case .int(let value):
-      return value
-    case .string(let value):
-      return value
-    }
-  }
-}
-
 /// RPC エラー応答の詳細。
 public struct RPCErrorDetail {
   public let code: Int
@@ -42,10 +10,10 @@ public struct RPCErrorDetail {
 /// RPC 成功応答。
 public struct RPCResponse<Result> {
   public let jsonrpc: String
-  public let id: RPCID
+  public let id: Int
   public let result: Result
 
-  public init(id: RPCID, result: Result) {
+  public init(id: Int, result: Result) {
     self.jsonrpc = "2.0"
     self.id = id
     self.result = result
@@ -64,7 +32,7 @@ final class RPCChannel {
   private let queue = DispatchQueue(
     label: "jp.shiguredo.sora-ios-sdk.rpc.channel", attributes: .concurrent)
   private var nextId: Int = 1
-  private var pendings: [RPCID: Pending] = [:]
+  private var pendings: [Int: Pending] = [:]
   private let allowedMethodNames: Set<String>
 
   init?(
@@ -114,11 +82,11 @@ final class RPCChannel {
       }
     }
 
-    var identifier: RPCID?
+    var identifier: Int?
     if !isNotificationRequest {
       let nextIdentifier = nextIdentifier()
       identifier = nextIdentifier
-      payload["id"] = nextIdentifier.jsonValue
+      payload["id"] = nextIdentifier
     }
 
     guard JSONSerialization.isValidJSONObject(payload) else {
@@ -204,8 +172,17 @@ final class RPCChannel {
       return
     }
 
-    guard let idValue = json["id"], let identifier = RPCID(any: idValue) else {
+    guard let idValue = json["id"] else {
       Logger.error(type: .dataChannel, message: "rpc response id is missing")
+      return
+    }
+    let identifier: Int
+    do {
+      identifier = try Self.parseResponseID(idValue)
+    } catch {
+      Logger.error(
+        type: .dataChannel,
+        message: "rpc response id is invalid: \(error.localizedDescription)")
       return
     }
 
@@ -229,7 +206,7 @@ final class RPCChannel {
 
   /// すべての pending を失敗扱いで終了する。
   func invalidate(reason: SoraError) {
-    let snapshots: [RPCID: Pending] = queue.sync(flags: .barrier) {
+    let snapshots: [Int: Pending] = queue.sync(flags: .barrier) {
       let current = pendings
       pendings.removeAll()
       return current
@@ -240,10 +217,10 @@ final class RPCChannel {
     }
   }
 
-  private func nextIdentifier() -> RPCID {
+  private func nextIdentifier() -> Int {
     queue.sync(flags: .barrier) {
       defer { nextId += 1 }
-      return RPCID.int(nextId)
+      return nextId
     }
   }
 
@@ -254,7 +231,7 @@ final class RPCChannel {
     return object
   }
 
-  private func finishPending(id: RPCID, result: Result<RPCResponse<Any>?, SoraError>) {
+  private func finishPending(id: Int, result: Result<RPCResponse<Any>?, SoraError>) {
     let pending = queue.sync(flags: .barrier) { () -> Pending? in
       let value = pendings[id]
       pendings.removeValue(forKey: id)
@@ -267,6 +244,29 @@ final class RPCChannel {
     }
     pending.timeoutWorkItem.cancel()
     pending.completion(result)
+  }
+
+  static func parseResponseID(_ value: Any) throws -> Int {
+    if let intValue = value as? Int {
+      return intValue
+    }
+    guard let numberValue = value as? NSNumber else {
+      throw SoraError.rpcDecodingError(reason: "response id の型が不正です: \(type(of: value))")
+    }
+    if CFGetTypeID(numberValue) == CFBooleanGetTypeID() {
+      throw SoraError.rpcDecodingError(reason: "response id に Bool は利用できません")
+    }
+    guard !CFNumberIsFloatType(numberValue) else {
+      throw SoraError.rpcDecodingError(reason: "response id は整数のみ利用できます: \(numberValue)")
+    }
+    let int64Value = numberValue.int64Value
+    guard NSNumber(value: int64Value) == numberValue else {
+      throw SoraError.rpcDecodingError(reason: "response id が Int の範囲外です: \(numberValue)")
+    }
+    guard let intValue = Int(exactly: int64Value) else {
+      throw SoraError.rpcDecodingError(reason: "response id が Int の範囲外です: \(numberValue)")
+    }
+    return intValue
   }
 }
 

--- a/Sora/RPC.swift
+++ b/Sora/RPC.swift
@@ -254,7 +254,7 @@ final class RPCChannel {
       return numberValue.intValue
     } else {
       throw SoraError.rpcDecodingError(
-        reason: "response id は Int または NSNumber である必要があります: \(type(of: value))")
+        reason: "response id must be Int or NSNumber: \(type(of: value))")
     }
   }
 }


### PR DESCRIPTION
JSON-RPC 2.0 リクエストオブジェクトの id は rpc 関数内で自動生成をしており、Int 型のみの対応で十分であったため、RPCID 型は削除し Int 型に変更しました。

RPCID は開発ブランチである develop でのみ存在する型であるため今回の変更は破壊的変更にはなりません。