### PR TITLE
画面キャプチャ機能を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   - MediaChannel に 画面キャプチャ開始 / 停止 API を追加する
   - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` クラスを追加する
     - targetFPS パラメータにより送信 FPS を指定することができる
+    - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する
   - @t-miya
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
   - MediaChannel に 画面キャプチャ開始 / 停止 API を追加する
+  - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` クラスを追加する
+    - targetFPS パラメータにより送信 FPS を指定することができる
   - 画面キャプチャには ReplayKit を利用する
   - @t-miya
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
   - MediaChannel に 画面キャプチャ開始 / 停止 API を追加する
-  - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` クラスを追加する
+  - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` 構造体を追加する
     - targetFPS パラメータにより送信 FPS を指定することができる
     - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,11 +12,14 @@
 ## develop
 
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
-  - MediaChannel に 画面キャプチャ開始 / 停止 API を追加する
+  - MediaChannel に画面キャプチャ開始 / 停止 API を追加する
   - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` 構造体を追加する
     - targetFPS パラメータにより送信 FPS を指定することができる
     - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する
+  - @t-miya
+- [FIX] MediaChannel の ScreenCaptureController 生成をスレッドセーフにする
+  - `getOrCreateScreenCaptureController` と参照取得を専用ロックで保護する
   - @t-miya
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+- [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
+  - MediaChannel に 画面キャプチャ開始 / 停止 API を追加する
+  - 画面キャプチャには ReplayKit を利用する
+  - @t-miya
+
 ### misc
 
 - [CHANGE] Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions の slack-notify に置き換える

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,6 @@
     - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する
   - @t-miya
-- [FIX] MediaChannel の ScreenCaptureController 生成をスレッドセーフにする
-  - `getOrCreateScreenCaptureController` と参照取得を専用ロックで保護する
-  - @t-miya
 
 ### misc
 

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -211,6 +211,11 @@ public final class CameraVideoCapturer {
       return
     }
 
+    if let error = errorIfScreenCaptureActive() {
+      completionHandler(error)
+      return
+    }
+
     native.startCapture(
       with: device,
       format: format,
@@ -272,6 +277,11 @@ public final class CameraVideoCapturer {
       return
     }
 
+    if let error = errorIfScreenCaptureActive() {
+      completionHandler(error)
+      return
+    }
+
     if isRunning {
       stop { [self] (error: Error?) in
         guard error == nil else {
@@ -306,6 +316,20 @@ public final class CameraVideoCapturer {
         completionHandler(nil)
       }
     }
+  }
+
+  // 同時複数入力経路は対応していないため、画面キャプチャ動作中はカメラを動作させないためのチェックです。
+  private func errorIfScreenCaptureActive() -> Error? {
+    guard let mediaChannel = stream?.mediaChannel else {
+      return nil
+    }
+    guard !mediaChannel.isScreenCaptureActiveForInternalCheck() else {
+      return SoraError.mediaChannelError(
+        reason:
+          "screen capture is active, stopScreenCapture before CameraVideoCapturer.start()/restart()"
+      )
+    }
+    return nil
   }
 
   /// カメラを停止後、指定されたパラメーターで起動します。

--- a/Sora/CameraVideoCapturer.swift
+++ b/Sora/CameraVideoCapturer.swift
@@ -211,11 +211,6 @@ public final class CameraVideoCapturer {
       return
     }
 
-    if let error = errorIfScreenCaptureActive() {
-      completionHandler(error)
-      return
-    }
-
     native.startCapture(
       with: device,
       format: format,
@@ -277,11 +272,6 @@ public final class CameraVideoCapturer {
       return
     }
 
-    if let error = errorIfScreenCaptureActive() {
-      completionHandler(error)
-      return
-    }
-
     if isRunning {
       stop { [self] (error: Error?) in
         guard error == nil else {
@@ -316,20 +306,6 @@ public final class CameraVideoCapturer {
         completionHandler(nil)
       }
     }
-  }
-
-  // 同時複数入力経路は対応していないため、画面キャプチャ動作中はカメラを動作させないためのチェックです。
-  private func errorIfScreenCaptureActive() -> Error? {
-    guard let mediaChannel = stream?.mediaChannel else {
-      return nil
-    }
-    guard !mediaChannel.isScreenCaptureActiveForInternalCheck() else {
-      return SoraError.mediaChannelError(
-        reason:
-          "screen capture is active, stopScreenCapture before CameraVideoCapturer.start()/restart()"
-      )
-    }
-    return nil
   }
 
   /// カメラを停止後、指定されたパラメーターで起動します。

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -839,6 +839,12 @@ public final class MediaChannel {
     currentScreenCaptureController()?.isCaptureActive() ?? false
   }
 
+  // CameraVideoCapturer からの内部チェック用です。
+  // 画面キャプチャの active 状態を返します。
+  func isScreenCaptureActiveForInternalCheck() -> Bool {
+    isScreenCaptureActive()
+  }
+
   // ScreenCaptureController をロック付きで取得します
   private func withScreenCaptureControllerLock<T>(_ block: () throws -> T) rethrows -> T {
     screenCaptureControllerLock.lock()

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -751,6 +751,13 @@ public final class MediaChannel {
         cameraSettings: configuration.cameraSettings
       )
     } else {
+      // 画面キャプチャ動作中はカメラを再開しません
+      guard !isScreenCaptureActive() else {
+        throw SoraError.mediaChannelError(
+          reason:
+            "screen capture is active, stopScreenCapture before setVideoHardMute(false)")
+      }
+
       // ハードミュート無効化 -> ソフトミュートによる黒塗りフレーム送出解除の順になるようにします
       try await Self.videoHardMuteActor.setMute(
         mute: false,
@@ -826,6 +833,10 @@ public final class MediaChannel {
     withScreenCaptureControllerLock {
       screenCaptureController
     }
+  }
+
+  private func isScreenCaptureActive() -> Bool {
+    currentScreenCaptureController()?.isCaptureActive() ?? false
   }
 
   // ScreenCaptureController をロック付きで取得します

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -761,6 +761,8 @@ public final class MediaChannel {
 
   /// MediaChannel の接続中に ReplayKit を利用して画面キャプチャおよび映像配信を開始します
   ///
+  /// 送信フレームレートは `ScreenCaptureSettings.targetFPS` で制御できます。
+  ///
   /// 同一 senderStream に対してカメラキャプチャが動作中の場合は開始できません。
   /// 接続前に `Configuration.initialCameraEnabled = false` を設定してください。
   ///

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -828,7 +828,7 @@ public final class MediaChannel {
     }
   }
 
-  // ScreenCaptureControllr をロック付きで取得します
+  // ScreenCaptureController をロック付きで取得します
   private func withScreenCaptureControllerLock<T>(_ block: () throws -> T) rethrows -> T {
     screenCaptureControllerLock.lock()
     defer { screenCaptureControllerLock.unlock() }

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -209,6 +209,9 @@ public final class MediaChannel {
 
   // ReplayKit を利用した画面キャプチャ制御です
   // インスタンスが必要な場合は getOrCreateScreenCaptureController 経由で取得します
+  // 生成後は MediaChannel のライフサイクルで保持します。
+  // stopScreenCapture / internalDisconnect から非同期停止を呼ぶため、
+  // 参照を途中で解放せずに同一インスタンスへ停止要求を集約します。
   private var screenCaptureController: ScreenCaptureController?
 
   // MARK: - インスタンスの生成

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -765,6 +765,7 @@ public final class MediaChannel {
   ///
   /// 同一 senderStream に対してカメラキャプチャが動作中の場合は開始できません。
   /// 接続前に `Configuration.initialCameraEnabled = false` を設定してください。
+  /// 接続後にカメラを停止する場合は `setVideoHardMute(true)` を先に呼んでください。
   ///
   /// - Parameter settings: 画面キャプチャ設定
   /// - Throws: エラー時は `SoraError.mediaChannelError` または ReplayKit 起因のエラーがスローされます

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -812,6 +812,11 @@ public final class MediaChannel {
     Logger.debug(type: .mediaChannel, message: "stopScreenCapture")
   }
 
+  /// 画面キャプチャが動作中かを取得します
+  public func isScreenCaptureActive() -> Bool {
+    currentScreenCaptureController()?.isCaptureActive() ?? false
+  }
+
   // screenCaptureController インスタンスを取得します
   // インスタンス未生成の場合は生成します
   // スクリーンキャプチャ機能は必ず利用するとは限らないため必要時に生成しています
@@ -833,16 +838,6 @@ public final class MediaChannel {
     withScreenCaptureControllerLock {
       screenCaptureController
     }
-  }
-
-  private func isScreenCaptureActive() -> Bool {
-    currentScreenCaptureController()?.isCaptureActive() ?? false
-  }
-
-  // CameraVideoCapturer からの内部チェック用です。
-  // 画面キャプチャの active 状態を返します。
-  func isScreenCaptureActiveForInternalCheck() -> Bool {
-    isScreenCaptureActive()
   }
 
   // ScreenCaptureController をロック付きで取得します

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -1,0 +1,299 @@
+import CoreMedia
+import Foundation
+import ReplayKit
+
+/// 画面キャプチャの設定です。
+public struct ScreenCaptureSettings {
+  /// ReplayKit のマイク入力を有効化するかどうか。
+  /// 既定値は `false` です。
+  public var isMicrophoneEnabled: Bool
+
+  /// ReplayKit のカメラ入力を有効化するかどうか。
+  /// 既定値は `false` です。
+  public var isCameraEnabled: Bool
+
+  /// 映像フレーム送信前に `CMSampleBuffer` を加工するためのクロージャーです。
+  /// `nil` を返すと該当フレームを破棄します。
+  public var videoSampleBufferTransformer: ((CMSampleBuffer) -> CMSampleBuffer?)?
+
+  /// 画面キャプチャ実行中に発生したエラー通知コールバックです。
+  public var onRuntimeError: ((Error) -> Void)?
+
+  /// 初期化します。
+  ///
+  /// - Parameters:
+  ///   - isMicrophoneEnabled: ReplayKit のマイク入力を有効化するかどうか
+  ///   - isCameraEnabled: ReplayKit のカメラ入力を有効化するかどうか
+  ///   - videoSampleBufferTransformer: 映像フレーム送信前の加工処理
+  ///   - onRuntimeError: 画面キャプチャ実行中エラーの通知コールバック
+  public init(
+    isMicrophoneEnabled: Bool = false,
+    isCameraEnabled: Bool = false,
+    videoSampleBufferTransformer: ((CMSampleBuffer) -> CMSampleBuffer?)? = nil,
+    onRuntimeError: ((Error) -> Void)? = nil
+  ) {
+    self.isMicrophoneEnabled = isMicrophoneEnabled
+    self.isCameraEnabled = isCameraEnabled
+    self.videoSampleBufferTransformer = videoSampleBufferTransformer
+    self.onRuntimeError = onRuntimeError
+  }
+}
+
+// スクリーンキャプチャーのコントローラークラスです。
+// 内部でロックと専用キューにより排他制御を行うため、 @unchecked Sendable を付与します。
+final class ScreenCaptureController: @unchecked Sendable {
+  // キャプチャー状況の列挙型
+  private enum CaptureState {
+    case stopped
+    case starting
+    case running
+    case stopping
+  }
+
+  private struct CaptureContext {
+    let senderStream: MediaStream
+    let videoSampleBufferTransformer: ((CMSampleBuffer) -> CMSampleBuffer?)?
+  }
+
+  private weak var mediaChannel: MediaChannel?
+  // ReplayKit のレコーダーです
+  private let recorder = RPScreenRecorder.shared()
+  // 画面フレームを順序保証して送信するためのキュー
+  private let sendVideoFrameQueue = DispatchQueue(
+    label: "jp.shiguredo.sora.screenCapture.sendVideoFrameQueue")
+  // 画面フレーム送信を常に1件だけに限定するためのセマフォ
+  private let sendVideoFrameSemaphore = DispatchSemaphore(value: 1)
+  private let lock = NSLock()
+
+  private var captureState: CaptureState = .stopped
+  private var settings = ScreenCaptureSettings()
+  private var senderStream: MediaStream?
+  // startCapture の非同期完了を世代管理するための ID です。
+  // start/stop が前後したときに、古い start 完了コールバックを無効化します。
+  private var captureID: UInt64 = 0
+  private var activeCaptureID: UInt64?
+
+  init(mediaChannel: MediaChannel) {
+    self.mediaChannel = mediaChannel
+  }
+
+  // 画面キャプチャを開始します
+  func startCapture(settings: ScreenCaptureSettings, senderStream: MediaStream) async throws {
+    let captureID = try beginStartCapture(settings: settings, senderStream: senderStream)
+
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      Task { @MainActor in
+        self.recorder.isMicrophoneEnabled = settings.isMicrophoneEnabled
+        self.recorder.isCameraEnabled = settings.isCameraEnabled
+        self.recorder.startCapture(
+          handler: { [weak self] sampleBuffer, sampleBufferType, error in
+            self?.handleSampleBuffer(
+              sampleBuffer: sampleBuffer,
+              sampleBufferType: sampleBufferType,
+              error: error
+            )
+          },
+          completionHandler: { [weak self] error in
+            guard let self else {
+              continuation.resume(
+                throwing: SoraError.mediaChannelError(
+                  reason: "ScreenCaptureController is unavailable"
+                )
+              )
+              return
+            }
+
+            switch self.completeStartCapture(captureID: captureID, error: error) {
+            case .success:
+              continuation.resume(returning: ())
+            case .failed(let error):
+              continuation.resume(throwing: error)
+            case .cancelled:
+              Task { [weak self] in
+                await self?.stopCapture()
+              }
+              continuation.resume(
+                throwing: SoraError.mediaChannelError(reason: "screen capture start was cancelled")
+              )
+            }
+          })
+      }
+    }
+  }
+
+  // 画面キャプチャを停止します
+  func stopCapture() async {
+    guard beginStopCapture() else {
+      return
+    }
+
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      Task { @MainActor in
+        self.recorder.stopCapture { _ in
+          self.withLock {
+            self.captureState = .stopped
+          }
+          continuation.resume(returning: ())
+        }
+      }
+    }
+  }
+
+  // 切断時に呼び出される stopCapture です。
+  // 呼び出し元で完了待ちをする必要はありません。
+  func stopCaptureForDisconnect() {
+    Task { [weak self] in
+      await self?.stopCapture()
+    }
+  }
+
+  // MARK: - Private
+
+  private enum StartCaptureResult {
+    case success
+    case failed(Error)
+    case cancelled
+  }
+
+  private func withLock<T>(_ block: () throws -> T) rethrows -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return try block()
+  }
+
+  // startCapture 前に state チェック、更新を行います
+  private func beginStartCapture(settings: ScreenCaptureSettings, senderStream: MediaStream) throws
+    -> UInt64
+  {
+    try withLock {
+      switch captureState {
+      case .running:
+        throw SoraError.mediaChannelError(reason: "screen capture is already running")
+      case .starting, .stopping:
+        throw SoraError.mediaChannelError(reason: "screen capture operation is in progress")
+      case .stopped:
+        captureID += 1
+        activeCaptureID = captureID
+        self.settings = settings
+        self.senderStream = senderStream
+        captureState = .starting
+        return captureID
+      }
+    }
+  }
+
+  // startCapture のコールバックが返ってきた後に state 更新等を行います
+  private func completeStartCapture(captureID: UInt64, error: Error?) -> StartCaptureResult {
+    withLock {
+      // startCapture 終了前に stopCapture が実行された場合はキャンセルします
+      // この時 activeCaptureID は nil となっています
+      guard activeCaptureID == captureID else {
+        return .cancelled
+      }
+
+      if let error {
+        captureState = .stopped
+        senderStream = nil
+        activeCaptureID = nil
+        return .failed(error)
+      }
+
+      captureState = .running
+      return .success
+    }
+  }
+
+  // stopCapture 実行前に state チェック等を行います
+  private func beginStopCapture() -> Bool {
+    withLock {
+      switch captureState {
+      case .stopped, .stopping:
+        return false
+      case .starting, .running:
+        captureState = .stopping
+        senderStream = nil
+        activeCaptureID = nil
+        return true
+      }
+    }
+  }
+
+  // キャプチャーした画面フレームを映像フレームに変換してストリーム送出します
+  // sendVideoFrameQueue でフレームの順序保証して送信します
+  // またキューが詰まるとメモリ使用量と遅延が増加していくため、sendVideoFrameSemaphore で
+  // 同時に処理できるフレームを1件に限定し、詰まったら待たずに破棄するようにしています。
+  private func handleSampleBuffer(
+    sampleBuffer: CMSampleBuffer,
+    sampleBufferType: RPSampleBufferType,
+    error: Error?
+  ) {
+    if let error {
+      let onRuntimeError = withLock { settings.onRuntimeError }
+      onRuntimeError?(error)
+      return
+    }
+
+    guard sampleBufferType == .video else {
+      return
+    }
+
+    guard let context = captureContext() else {
+      return
+    }
+
+    // 即取得できなければフレーム詰まりを回避するためにこのフレームは破棄します
+    guard sendVideoFrameSemaphore.wait(timeout: .now()) == .success else {
+      return
+    }
+    sendVideoFrameQueue.async { [weak self] in
+      // sendVideoFrameSemaphore カウントを -1 して次のフレームを処理できるようにします
+      defer { self?.sendVideoFrameSemaphore.signal() }
+
+      // 非同期 stopCapture で captureState が変更される可能性があるためここでチェックします
+      guard let self, self.isReadyToSend() else {
+        return
+      }
+
+      var sampleBufferToSend = sampleBuffer
+      if let transformedBuffer = context.videoSampleBufferTransformer?(sampleBuffer) {
+        sampleBufferToSend = transformedBuffer
+      } else if context.videoSampleBufferTransformer != nil {
+        return
+      }
+
+      guard let videoFrame = VideoFrame(from: sampleBufferToSend) else {
+        return
+      }
+
+      context.senderStream.send(videoFrame: videoFrame)
+    }
+  }
+
+  private func captureContext() -> CaptureContext? {
+    withLock {
+      guard captureState == .running else {
+        return nil
+      }
+      guard let senderStream else {
+        return nil
+      }
+      return CaptureContext(
+        senderStream: senderStream,
+        videoSampleBufferTransformer: settings.videoSampleBufferTransformer
+      )
+    }
+  }
+
+  // ストリーム送出できる状態かチェックします
+  private func isReadyToSend() -> Bool {
+    withLock {
+      guard captureState == .running else {
+        return false
+      }
+      guard mediaChannel?.state == .connected else {
+        return false
+      }
+      return true
+    }
+  }
+}

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -174,6 +174,8 @@ final class ScreenCaptureController: @unchecked Sendable {
       case .stopped:
         captureID += 1
         activeCaptureID = captureID
+        // start の世代に紐づく設定をここで確定します。
+        // 後続世代の start が走った場合は captureID で旧世代コールバックを無効化します。
         self.settings = settings
         self.senderStream = senderStream
         captureState = .starting

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -134,7 +134,13 @@ final class ScreenCaptureController: @unchecked Sendable {
 
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
       Task { @MainActor in
-        self.recorder.stopCapture { _ in
+        self.recorder.stopCapture { error in
+          if let error {
+            Logger.error(
+              type: .mediaChannel,
+              message: "failed to stop screen capture: \(error.localizedDescription)"
+            )
+          }
           self.withLock {
             self.captureState = .stopped
           }

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -4,11 +4,17 @@ import ReplayKit
 
 /// 画面キャプチャの設定です。
 public struct ScreenCaptureSettings {
-  /// ReplayKit のマイク入力を有効化するかどうか。
+  /// ReplayKit の `RPScreenRecorder.isMicrophoneEnabled` に対応する設定です。
+  /// `true` の場合、 ReplayKit 側でマイク入力を有効化します。
+  /// ただし現状の SDK は `RPSampleBufferType.video` のみ送信するため、
+  /// この設定を `true` にしても Sora へ音声は送信されません。
   /// 既定値は `false` です。
   public var isMicrophoneEnabled: Bool
 
-  /// ReplayKit のカメラ入力を有効化するかどうか。
+  /// ReplayKit の `RPScreenRecorder.isCameraEnabled` に対応する設定です。
+  /// `true` の場合、 ReplayKit のカメラプレビュー機能を利用できます。
+  /// ただし現状の SDK は画面の `RPSampleBufferType.video` のみ送信するため、
+  /// ReplayKit カメラ映像の合成や送信は行いません。
   /// 既定値は `false` です。
   public var isCameraEnabled: Bool
 
@@ -22,8 +28,8 @@ public struct ScreenCaptureSettings {
   /// 初期化します。
   ///
   /// - Parameters:
-  ///   - isMicrophoneEnabled: ReplayKit のマイク入力を有効化するかどうか
-  ///   - isCameraEnabled: ReplayKit のカメラ入力を有効化するかどうか
+  ///   - isMicrophoneEnabled: `RPScreenRecorder.isMicrophoneEnabled` に渡す値
+  ///   - isCameraEnabled: `RPScreenRecorder.isCameraEnabled` に渡す値
   ///   - videoSampleBufferTransformer: 映像フレーム送信前の加工処理
   ///   - onRuntimeError: 画面キャプチャ実行中エラーの通知コールバック
   public init(

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -162,6 +162,14 @@ final class ScreenCaptureController: @unchecked Sendable {
     }
   }
 
+  // 画面キャプチャが動作中かどうかを返します。
+  // starting / running / stopping を動作中として扱います。
+  func isCaptureActive() -> Bool {
+    withLock {
+      captureState != .stopped
+    }
+  }
+
   // MARK: - Private
 
   private enum StartCaptureResult {

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -31,7 +31,7 @@ public struct ScreenCaptureSettings {
     videoSampleBufferTransformer: ((CMSampleBuffer) -> CMSampleBuffer?)? = nil,
     onRuntimeError: ((Error) -> Void)? = nil
   ) {
-    self.targetFPS = max(1, targetFPS)
+    self.targetFPS = min(max(1, targetFPS), 120)
     self.videoSampleBufferTransformer = videoSampleBufferTransformer
     self.onRuntimeError = onRuntimeError
   }
@@ -251,13 +251,13 @@ final class ScreenCaptureController: @unchecked Sendable {
       return
     }
 
-    // PTS を取得して、targetFPS との比較から、今回のフレームを送信するか判定します
-    let presentationTimestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-    guard shouldSendVideoFrame(presentationTimestamp: presentationTimestamp) else {
+    guard let context = captureContext() else {
       return
     }
 
-    guard let context = captureContext() else {
+    // PTS を取得して、targetFPS との比較から、今回のフレームを送信するか判定します
+    let presentationTimestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+    guard shouldSendVideoFrame(presentationTimestamp: presentationTimestamp) else {
       return
     }
 

--- a/Sora/ScreenCapture.swift
+++ b/Sora/ScreenCapture.swift
@@ -18,6 +18,8 @@ public struct ScreenCaptureSettings {
   public var videoSampleBufferTransformer: ((CMSampleBuffer) -> CMSampleBuffer?)?
 
   /// 画面キャプチャ実行中に発生したエラー通知コールバックです。
+  /// 通知専用のため、このコールバック呼び出しではキャプチャ停止を行いません。
+  /// 停止が必要な場合は利用側で `MediaChannel.stopScreenCapture()` を呼び出してください。
   public var onRuntimeError: ((Error) -> Void)?
 
   /// 初期化します。
@@ -26,6 +28,8 @@ public struct ScreenCaptureSettings {
   ///   - targetFPS: 送信する映像フレームレートの目標値
   ///   - videoSampleBufferTransformer: 映像フレーム送信前の加工処理
   ///   - onRuntimeError: 画面キャプチャ実行中エラーの通知コールバック
+  ///     - 通知専用のため、このコールバック呼び出しではキャプチャ停止を行いません
+  ///     - 停止が必要な場合は利用側で `MediaChannel.stopScreenCapture()` を呼び出してください
   public init(
     targetFPS: Int = 15,
     videoSampleBufferTransformer: ((CMSampleBuffer) -> CMSampleBuffer?)? = nil,


### PR DESCRIPTION
iOS 端末の画面を ReplayKit を利用してキャプチャし、映像フレームに変換して配信する機能を追加します
- キャプチャ用のモジュールとして ScreenCapture を追加しました
- MediaChannel に公開 API `startScreenCapture` `stopScreenCapture` を追加しました
- マイク、カメラの併用は現状対応していません