### PR TITLE
Slack 通知を shiguredo/github-actions の slack-notify に置き換える

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "actions/checkout"
-      - dependency-name: "rtCamp/action-slack-notify"
+      - dependency-name: "shiguredo/github-actions"
       - dependency-name: "anthropics/claude-code-action"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,29 +46,16 @@ jobs:
     - name: Lint
       run: |
         make lint
-  slack_notify_succeeded:
+  slack_notify:
     needs: [build]
     runs-on: ubuntu-24.04
-    if: success()
+    if: always()
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-ios-sdk
-          SLACK_COLOR: good
-          SLACK_TITLE: SUCCEEDED
-          SLACK_ICON_EMOJI: ":star-struck:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  slack_notify_failed:
-    needs: [build]
-    runs-on: ubuntu-24.04
-    if: failure()
-    steps:
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-ios-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: "FAILED"
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-ios-sdk


### PR DESCRIPTION
## Summary

- rtCamp/action-slack-notify@v2 を shiguredo/github-actions/.github/actions/slack-notify@main に置き換え
- slack_notify_succeeded と slack_notify_failed の 2 ジョブを 1 つの slack_notify ジョブに統合
- Fixed 通知 (前回 failure → 今回 success) に対応
- dependabot.yml の依存先を shiguredo/github-actions に変更