### PR TITLE
音声入力経路の変更イベントハンドラを追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,8 @@
 
 - [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する
   - `RTCAudioSessionDelegate.audioSessionDidChangeRoute` を利用してコールバックする
-  - ハンズフリー状態などの評価はコールバック内で `RTCAudioSession.currentRoute` を参照する
-  - @t-miya
-- [ADD] ハンズフリーの設定と判定を行う API を追加する
-  - `Sora.setHandsfree(_:)` と `Sora.isHandsfree()` を追加する
-  - ハンズフリー状態は内蔵スピーカー + 内蔵マイクの組み合わせで判定する
+  - コールバック引数として `RTCAudioSession` と `previousRoute` を渡す
+  - 音声ルートの状態などの評価はコールバック内で `RTCAudioSession.currentRoute` を参照する
   - @t-miya
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
   - MediaChannel に画面キャプチャ開始 / 停止 API を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   - `RTCAudioSessionDelegate.audioSessionDidChangeRoute` を利用してコールバックする
   - ハンズフリー状態などの評価はコールバック内で `RTCAudioSession.currentRoute` を参照する
   - @t-miya
+- [ADD] ハンズフリーの設定と判定を行う API を追加する
+  - `Sora.setHandsfree(_:)` と `Sora.isHandsfree()` を追加する
+  - ハンズフリー状態は内蔵スピーカー + 内蔵マイクの組み合わせで判定する
+  - @t-miya
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
   - MediaChannel に画面キャプチャ開始 / 停止 API を追加する
   - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` 構造体を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する
+  - `RTCAudioSessionDelegate.audioSessionDidChangeRoute` を利用してコールバックする
+  - ハンズフリー状態などの評価はコールバック内で `RTCAudioSession.currentRoute` を参照する
+  - @t-miya
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する
   - MediaChannel に画面キャプチャ開始 / 停止 API を追加する
   - 画面キャプチャ開始時に渡す設定として `ScreenCaptureSettings` 構造体を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する
   - `RTCAudioSessionDelegate.audioSessionDidChangeRoute` を利用してコールバックする
-  - コールバック引数として `RTCAudioSession` と `previousRoute` を渡す
+  - コールバック引数として `RTCAudioSession`, `reason`, `previousRoute` を渡す
   - 音声ルートの状態などの評価はコールバック内で `RTCAudioSession.currentRoute` を参照する
   - @t-miya
 - [ADD] iOS 端末画面をキャプチャして配信する ScreenCapture を追加する

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -19,8 +19,14 @@ public final class SoraHandlers {
   /// 音声入出力ルートが変更されたときに呼ばれるクロージャー
   ///
   /// - parameter session: 変更通知元の `RTCAudioSession`
+  /// - parameter reason: 変更理由
   /// - parameter previousRoute: 変更前のルート情報
-  public var onChangeAudioRoute: ((RTCAudioSession, AVAudioSessionRouteDescription) -> Void)?
+  public var onChangeAudioRoute:
+    (
+      (
+        RTCAudioSession, AVAudioSession.RouteChangeReason, AVAudioSessionRouteDescription
+      ) -> Void
+    )?
 
   /// 初期化します。
   public init() {}
@@ -71,8 +77,8 @@ public final class Sora {
   public let handlers = SoraHandlers()
 
   private lazy var audioSessionDelegateAdapter = SoraRTCAudioSessionDelegateAdapter {
-    [weak self] session, previousRoute in
-    self?.handlers.onChangeAudioRoute?(session, previousRoute)
+    [weak self] session, reason, previousRoute in
+    self?.handlers.onChangeAudioRoute?(session, reason, previousRoute)
   }
 
   // MARK: - インスタンスの生成と取得
@@ -406,9 +412,17 @@ public final class ConnectionTask {
 // 3. SoraRTCAudioSessionDelegateAdapter(本クラス) の audioSessionDidChangeRoute で通知を受ける
 // 4. onChangeAudioRoute で SDK 利用者へ通知する
 private final class SoraRTCAudioSessionDelegateAdapter: NSObject, RTCAudioSessionDelegate {
-  private let onChangeAudioRoute: (RTCAudioSession, AVAudioSessionRouteDescription) -> Void
+  private let onChangeAudioRoute:
+    (
+      RTCAudioSession, AVAudioSession.RouteChangeReason, AVAudioSessionRouteDescription
+    ) -> Void
 
-  init(onChangeAudioRoute: @escaping (RTCAudioSession, AVAudioSessionRouteDescription) -> Void) {
+  init(
+    onChangeAudioRoute:
+      @escaping (
+        RTCAudioSession, AVAudioSession.RouteChangeReason, AVAudioSessionRouteDescription
+      ) -> Void
+  ) {
     self.onChangeAudioRoute = onChangeAudioRoute
   }
 
@@ -420,12 +434,12 @@ private final class SoraRTCAudioSessionDelegateAdapter: NSObject, RTCAudioSessio
     switch reason {
     case .unknown, .newDeviceAvailable, .oldDeviceUnavailable, .categoryChange, .override,
       .wakeFromSleep, .noSuitableRouteForCategory:
-      onChangeAudioRoute(session, previousRoute)
+      onChangeAudioRoute(session, reason, previousRoute)
     case .routeConfigurationChange:
       // WebRTC 側でも routeConfigurationChange を無視しているため、ここでも無視します
       break
     @unknown default:
-      onChangeAudioRoute(session, previousRoute)
+      onChangeAudioRoute(session, reason, previousRoute)
     }
   }
 }

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -456,7 +456,7 @@ private final class SoraRTCAudioSessionDelegateAdapter: NSObject, RTCAudioSessio
       .wakeFromSleep, .noSuitableRouteForCategory:
       onChangeAudioRoute()
     case .routeConfigurationChange:
-      // webrtc 側でもヘッドセットの接続変化検出に注力のため無視しているためここでも無視します
+      // WebRTC 側でも routeConfigurationChange を無視しているため、ここでも無視します
       break
     @unknown default:
       onChangeAudioRoute()

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -16,6 +16,11 @@ public final class SoraHandlers {
   /// メディアチャネルが除去されたときに呼ばれるクロージャー
   public var onRemoveMediaChannel: ((MediaChannel) -> Void)?
 
+  /// 音声入出力ルートが変更されたときに呼ばれるクロージャー
+  ///
+  /// ハンズフリー状態などの現在値が必要な場合は、`RTCAudioSession.currentRoute` を参照してください。
+  public var onChangeAudioRoute: (() -> Void)?
+
   /// 初期化します。
   public init() {}
 }
@@ -64,6 +69,11 @@ public final class Sora {
   /// イベントハンドラ
   public let handlers = SoraHandlers()
 
+  private lazy var audioSessionDelegateAdapter = SoraRTCAudioSessionDelegateAdapter {
+    [weak self] in
+    self?.handlers.onChangeAudioRoute?()
+  }
+
   // MARK: - インスタンスの生成と取得
 
   /// シングルトンインスタンス
@@ -87,6 +97,11 @@ public final class Sora {
     // which is fatal to the initialization logic.
     // The following line will NEVER fail.
     if !initialized { fatalError() }
+    RTCAudioSession.sharedInstance().add(audioSessionDelegateAdapter)
+  }
+
+  deinit {
+    RTCAudioSession.sharedInstance().remove(audioSessionDelegateAdapter)
   }
 
   // MARK: - メディアチャネルの管理
@@ -377,6 +392,42 @@ public final class ConnectionTask {
     if state != .completed {
       Logger.debug(type: .mediaChannel, message: "connection task completed")
       state = .completed
+    }
+  }
+}
+
+// RTCAudioSessionDelegate を実装し、audioSessionDidChangeRoute イベントを受けて、
+// handlers.onChangeAudioRoute を呼び出す中継クラスです。
+//
+// オーディオ経路変更通知の流れ
+// 1. オーディオ経路の変更を RTCAudioSession::handleRouteChangeNotification で AVAudioSessionRouteChangeNotification で受信
+// 2. RTCAudioSession::notifyDidChangeRouteWithReason で audioSessionDidChangeRoute:reason:previousRoute: が呼ばれる
+// 3. SoraRTCAudioSessionDelegateAdapter(本クラス) の audioSessionDidChangeRoute で通知を受ける
+// 4. onChangeAudioRoute で SDK 利用者へ通知する
+private final class SoraRTCAudioSessionDelegateAdapter: NSObject, RTCAudioSessionDelegate {
+  private let onChangeAudioRoute: () -> Void
+
+  init(onChangeAudioRoute: @escaping () -> Void) {
+    self.onChangeAudioRoute = onChangeAudioRoute
+  }
+
+  // 現状、ルート変更が起きたことを通知する機能、のみを提供します
+  func audioSessionDidChangeRoute(
+    _ session: RTCAudioSession,
+    reason: AVAudioSession.RouteChangeReason,
+    previousRoute: AVAudioSessionRouteDescription
+  ) {
+    _ = session
+    _ = previousRoute
+    switch reason {
+    case .unknown, .newDeviceAvailable, .oldDeviceUnavailable, .categoryChange, .override,
+      .wakeFromSleep, .noSuitableRouteForCategory:
+      onChangeAudioRoute()
+    case .routeConfigurationChange:
+      // webrtc 側でもヘッドセットの接続変化検出に注力のため無視している、ルートのため無視します
+      break
+    @unknown default:
+      onChangeAudioRoute()
     }
   }
 }

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -18,8 +18,9 @@ public final class SoraHandlers {
 
   /// 音声入出力ルートが変更されたときに呼ばれるクロージャー
   ///
-  /// ハンズフリー状態などの現在値が必要な場合は、`RTCAudioSession.currentRoute` を参照してください。
-  public var onChangeAudioRoute: (() -> Void)?
+  /// - parameter session: 変更通知元の `RTCAudioSession`
+  /// - parameter previousRoute: 変更前のルート情報
+  public var onChangeAudioRoute: ((RTCAudioSession, AVAudioSessionRouteDescription) -> Void)?
 
   /// 初期化します。
   public init() {}
@@ -70,8 +71,8 @@ public final class Sora {
   public let handlers = SoraHandlers()
 
   private lazy var audioSessionDelegateAdapter = SoraRTCAudioSessionDelegateAdapter {
-    [weak self] in
-    self?.handlers.onChangeAudioRoute?()
+    [weak self] session, previousRoute in
+    self?.handlers.onChangeAudioRoute?(session, previousRoute)
   }
 
   // MARK: - インスタンスの生成と取得
@@ -306,38 +307,6 @@ public final class Sora {
     }
   }
 
-  /// ハンズフリーの有効 / 無効を設定します。
-  ///
-  /// `true` の場合は内蔵スピーカー + 内蔵マイクの組み合わせに切り替えます。
-  /// `false` の場合はオーディオ出力オーバーライドを解除します。
-  ///
-  /// - parameter enable: `true` で有効、`false` で無効
-  /// - returns: 変更の成否
-  public func setHandsfree(_ enable: Bool) -> Result<Void, Error> {
-    do {
-      let session = RTCAudioSession.sharedInstance()
-      session.lockForConfiguration()
-      defer {
-        session.unlockForConfiguration()
-      }
-      let overrideOutput: AVAudioSession.PortOverride = enable ? .speaker : .none
-      try session.overrideOutputAudioPort(overrideOutput)
-      return .success(())
-    } catch {
-      return .failure(error)
-    }
-  }
-
-  /// 現在がハンズフリー状態かどうかを返します。
-  ///
-  /// 内蔵スピーカー + 内蔵マイクの組み合わせをハンズフリー状態とみなします。
-  public func isHandsfree() -> Bool {
-    let session = RTCAudioSession.sharedInstance()
-    let output = session.currentRoute.outputs.first?.portType
-    let input = session.currentRoute.inputs.first?.portType
-    return output == .builtInSpeaker && input == .builtInMic
-  }
-
   // MARK: - libwebrtc のログ出力
 
   private static var webRTCCallbackLogger: RTCCallbackLogger = {
@@ -437,29 +406,26 @@ public final class ConnectionTask {
 // 3. SoraRTCAudioSessionDelegateAdapter(本クラス) の audioSessionDidChangeRoute で通知を受ける
 // 4. onChangeAudioRoute で SDK 利用者へ通知する
 private final class SoraRTCAudioSessionDelegateAdapter: NSObject, RTCAudioSessionDelegate {
-  private let onChangeAudioRoute: () -> Void
+  private let onChangeAudioRoute: (RTCAudioSession, AVAudioSessionRouteDescription) -> Void
 
-  init(onChangeAudioRoute: @escaping () -> Void) {
+  init(onChangeAudioRoute: @escaping (RTCAudioSession, AVAudioSessionRouteDescription) -> Void) {
     self.onChangeAudioRoute = onChangeAudioRoute
   }
 
-  // 現状、ルート変更が起きたことを通知する機能、のみを提供します
   func audioSessionDidChangeRoute(
     _ session: RTCAudioSession,
     reason: AVAudioSession.RouteChangeReason,
     previousRoute: AVAudioSessionRouteDescription
   ) {
-    _ = session
-    _ = previousRoute
     switch reason {
     case .unknown, .newDeviceAvailable, .oldDeviceUnavailable, .categoryChange, .override,
       .wakeFromSleep, .noSuitableRouteForCategory:
-      onChangeAudioRoute()
+      onChangeAudioRoute(session, previousRoute)
     case .routeConfigurationChange:
       // WebRTC 側でも routeConfigurationChange を無視しているため、ここでも無視します
       break
     @unknown default:
-      onChangeAudioRoute()
+      onChangeAudioRoute(session, previousRoute)
     }
   }
 }

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -333,10 +333,6 @@ public final class Sora {
   /// 内蔵スピーカー + 内蔵マイクの組み合わせをハンズフリー状態とみなします。
   public func isHandsfree() -> Bool {
     let session = RTCAudioSession.sharedInstance()
-    session.lockForConfiguration()
-    defer {
-      session.unlockForConfiguration()
-    }
     let output = session.currentRoute.outputs.first?.portType
     let input = session.currentRoute.inputs.first?.portType
     return output == .builtInSpeaker && input == .builtInMic
@@ -460,7 +456,7 @@ private final class SoraRTCAudioSessionDelegateAdapter: NSObject, RTCAudioSessio
       .wakeFromSleep, .noSuitableRouteForCategory:
       onChangeAudioRoute()
     case .routeConfigurationChange:
-      // webrtc 側でもヘッドセットの接続変化検出に注力のため無視している、ルートのため無視します
+      // webrtc 側でもヘッドセットの接続変化検出に注力のため無視しているためここでも無視します
       break
     @unknown default:
       onChangeAudioRoute()

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -306,6 +306,42 @@ public final class Sora {
     }
   }
 
+  /// ハンズフリーの有効 / 無効を設定します。
+  ///
+  /// `true` の場合は内蔵スピーカー + 内蔵マイクの組み合わせに切り替えます。
+  /// `false` の場合はオーディオ出力オーバーライドを解除します。
+  ///
+  /// - parameter enable: `true` で有効、`false` で無効
+  /// - returns: 変更の成否
+  public func setHandsfree(_ enable: Bool) -> Result<Void, Error> {
+    do {
+      let session = RTCAudioSession.sharedInstance()
+      session.lockForConfiguration()
+      defer {
+        session.unlockForConfiguration()
+      }
+      let overrideOutput: AVAudioSession.PortOverride = enable ? .speaker : .none
+      try session.overrideOutputAudioPort(overrideOutput)
+      return .success(())
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  /// 現在がハンズフリー状態かどうかを返します。
+  ///
+  /// 内蔵スピーカー + 内蔵マイクの組み合わせをハンズフリー状態とみなします。
+  public func isHandsfree() -> Bool {
+    let session = RTCAudioSession.sharedInstance()
+    session.lockForConfiguration()
+    defer {
+      session.unlockForConfiguration()
+    }
+    let output = session.currentRoute.outputs.first?.portType
+    let input = session.currentRoute.inputs.first?.portType
+    return output == .builtInSpeaker && input == .builtInMic
+  }
+
   // MARK: - libwebrtc のログ出力
 
   private static var webRTCCallbackLogger: RTCCallbackLogger = {


### PR DESCRIPTION
`Sora.onChangeAudioRoute` を追加して、音声入力経路が変更された際に通知を受け取れるようにしました。
コールバック引数の session, reason, previous_route で現在の経路、変更理由、変更前ルートを取得することができます。