### PR TITLE
setAudioMode に入力経路オーバーライドのリセットを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] `Sora.setAudioMode` で AudioMode が `.default` であれば入力経路のオーバーライドをリセットする
+  - @t-miya
 - [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する
   - `RTCAudioSessionDelegate.audioSessionDidChangeRoute` を利用してコールバックする
   - コールバック引数として `RTCAudioSession`, `reason`, `previousRoute` を渡す

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,6 @@
 
 ## develop
 
-- [UPDATE] `Sora.setAudioMode` で AudioMode が `.default` であれば入力経路のオーバーライドをリセットする
-  - @t-miya
 - [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する
   - `RTCAudioSessionDelegate.audioSessionDidChangeRoute` を利用してコールバックする
   - コールバック引数として `RTCAudioSession`, `reason`, `previousRoute` を渡す
@@ -24,6 +22,9 @@
     - targetFPS パラメータにより送信 FPS を指定することができる
     - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する
+  - @t-miya
+- [UPDATE] `Sora.setAudioMode` で AudioMode が `.default` であれば入力経路のオーバーライドをリセットする
+  - 入力経路を `.speaker` にオーバーライドした後に他モードを指定しても経路がリセットされなかったため
   - @t-miya
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@
     - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する
   - @t-miya
-- [UPDATE] `Sora.setAudioMode` で AudioMode が `.default` であれば入力経路のオーバーライドをリセットする
+- [FIX] `Sora.setAudioMode` で AudioMode が `.default` であれば入力経路のオーバーライドをリセットする
   - 入力経路を `.speaker` にオーバーライドした後に他モードを指定しても経路がリセットされなかったため
   - @t-miya
 

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -289,6 +289,9 @@ public final class Sora {
       defer {
         session.unlockForConfiguration()
       }
+      // 音声出力経路のリセットを行います。
+      // RTCAudioSession.overrideOutputAudioPort はカテゴリが playAndRecord の場合のみ有効なため
+      // カテゴリ遷移前のこの状態でリセットを行います。
       if shouldResetPortOverride(for: mode)
         && session.category == AVAudioSession.Category.playAndRecord.rawValue
       {

--- a/Sora/Sora.swift
+++ b/Sora/Sora.swift
@@ -286,6 +286,14 @@ public final class Sora {
       var options = options
       let session = RTCAudioSession.sharedInstance()
       session.lockForConfiguration()
+      defer {
+        session.unlockForConfiguration()
+      }
+      if shouldResetPortOverride(for: mode)
+        && session.category == AVAudioSession.Category.playAndRecord.rawValue
+      {
+        try session.overrideOutputAudioPort(.none)
+      }
       switch mode {
       case .default(let category, let output):
         if output == .speaker {
@@ -302,14 +310,23 @@ public final class Sora {
         }
         try session.setCategory(.playAndRecord, with: options)
         try session.setMode(.voiceChat)
-        if output == .speaker {
-          try session.overrideOutputAudioPort(.speaker)
-        }
+        try session.overrideOutputAudioPort(output.portOverride)
       }
-      session.unlockForConfiguration()
       return .success(())
     } catch {
       return .failure(error)
+    }
+  }
+
+  // setAudioMode にて音声入力経路のリセットを行うか判定します
+  private func shouldResetPortOverride(for mode: AudioMode) -> Bool {
+    switch mode {
+    case .default(_, let output):
+      return output == .default
+    case .videoChat:
+      return false
+    case .voiceChat(let output):
+      return output == .default
     }
   }
 


### PR DESCRIPTION
setAudioMode で .speaker 時に行っていた入力経路のオーバーライドが一方通行で他の Mode に切り替えた際でも
戻らない状態となっていたため修正する