### PR TITLE
canary 実行前に更新確認を追加する

### DIFF
--- a/canary.py
+++ b/canary.py
@@ -165,7 +165,7 @@ def main():
     )
 
     if not args.dry_run and not confirm_execution(current_version, new_version):
-        print("処理を中止しました。")
+        print("Canceled.")
         return
 
     write_file(PACKAGEINFO_FILE, updated_packageinfo_content, args.dry_run)

--- a/canary.py
+++ b/canary.py
@@ -15,13 +15,14 @@ def update_packageinfo_version(packageinfo_content):
         packageinfo_content (list): PackageInfo.swiftファイルの各行を要素とするリスト
 
     Returns:
-        tuple: (更新後のファイル内容のリスト, 新しいバージョン文字列)
+        tuple: (更新後のファイル内容のリスト, 現在のバージョン文字列, 新しいバージョン文字列)
 
     Raises:
         ValueError: バージョン指定が見つからない場合
     """
     updated_content = []
     sdk_version_updated = False
+    current_version = None
     new_version = None
 
     for line in packageinfo_content:
@@ -35,6 +36,7 @@ def update_packageinfo_version(packageinfo_content):
             if version_match:
                 major_minor_patch = version_match.group(1)  # 基本バージョン (例: 1.0.0)
                 canary_suffix = version_match.group(2)  # canaryサフィックス部分
+                current_version = f"{major_minor_patch}{canary_suffix or ''}"
 
                 # canaryサフィックスが無い場合は.0から開始、ある場合は番号をインクリメント
                 if canary_suffix is None:
@@ -54,7 +56,7 @@ def update_packageinfo_version(packageinfo_content):
     if not sdk_version_updated:
         raise ValueError("Version specification not found in PackageInfo.swift file.")
 
-    return updated_content, new_version
+    return updated_content, current_version, new_version
 
 
 def write_file(filename, updated_content, dry_run):
@@ -116,6 +118,28 @@ def git_operations(new_version, dry_run):
         subprocess.run(["git", "push", "origin", new_version], check=True)
 
 
+def confirm_execution(current_version, new_version):
+    """
+    通常実行時に y / n の確認を行う
+
+    Args:
+        current_version (str): 現在のバージョン文字列
+        new_version (str): 作成予定のバージョン文字列
+
+    Returns:
+        bool: 実行を継続する場合は True、 中止する場合は False
+    """
+    while True:
+        answer = input(
+            f"Update version from {current_version} to {new_version}? (y/n): "
+        ).strip().lower()
+        if answer == "y":
+            return True
+        if answer == "n":
+            return False
+        print("Please enter y or n.")
+
+
 def main():
     """
     メイン処理:
@@ -136,7 +160,14 @@ def main():
     # PackageInfoファイルを読み込んでバージョンを更新
     with open(PACKAGEINFO_FILE, "r", encoding="utf-8") as file:
         packageinfo_content = file.readlines()
-    updated_packageinfo_content, new_version = update_packageinfo_version(packageinfo_content)
+    updated_packageinfo_content, current_version, new_version = update_packageinfo_version(
+        packageinfo_content
+    )
+
+    if not args.dry_run and not confirm_execution(current_version, new_version):
+        print("処理を中止しました。")
+        return
+
     write_file(PACKAGEINFO_FILE, updated_packageinfo_content, args.dry_run)
 
     # Git操作の実行


### PR DESCRIPTION
## 概要
- canary.py の通常実行時 ( --dry-run 以外 ) に、実行前の y / n 確認を追加
- `--dry-run` の動作は従来どおり ( 確認なし )