### PR TITLE
libwebrtc を m146.7680.0.1 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 - [UPDATE] `URLSessionWebSocketChannel` と `Proxy` を Swift 6 の `Sendable` 要件に対応させる
   - `URLSessionWebSocketChannel` を `final class` かつ `@unchecked Sendable` とし、 `Proxy` を `Sendable` に対応させる
   - @zztkm
+- [UPDATE] libwebrtc m146.7680.0.1 に上げる
+  - @zztkm
 - [ADD] MediaChannelHandlers にシグナリングメッセージを JSON 文字列として取得する `onReceiveSignalingJSON` を追加する
   - @zztkm
 - [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-let libwebrtcVersion = "m144.7559.2.2"
+let libwebrtcVersion = "m146.7680.0.1"
 
 let package = Package(
     name: "Sora",
@@ -21,7 +21,7 @@ let package = Package(
         .binaryTarget(
             name: "WebRTC",
             url: "https://github.com/shiguredo-webrtc-build/webrtc-build/releases/download/\(libwebrtcVersion)/WebRTC.xcframework.zip",
-            checksum: "5e13c05f4684b9c0478079a49c11225d9bcaea2bbb5e0b3abec2ad3bda91f56d"
+            checksum: "cb6ce2168c12d73160441e89168f4b74c61f92aa3c2913c2a9962304851569d6"
         ),
         .target(
             name: "Sora",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sora iOS SDK
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-144.7559-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/7559)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-146.7680-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/7680)
 [![GitHub tag](https://img.shields.io/github/tag/shiguredo/sora-ios-sdk.svg)](https://github.com/shiguredo/sora-ios-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/Sora/PackageInfo.swift
+++ b/Sora/PackageInfo.swift
@@ -7,19 +7,19 @@ public enum SDKInfo {
 /// WebRTC フレームワークの情報を表します。
 public enum WebRTCInfo {
   /// WebRTC フレームワークのバージョン
-  public static let version = "M144"
+  public static let version = "M146"
 
   /// WebRTC の branch-heads
-  public static let branch = "7559"
+  public static let branch = "7680"
 
   /// WebRTC フレームワークのコミットポジション
-  public static let commitPosition = "2"
+  public static let commitPosition = "0"
 
   /// WebRTC フレームワークのメンテナンスバージョン
   public static let maintenanceVersion = "1"
 
   /// WebRTC フレームワークのソースコードのリビジョン
-  public static let revision = "8f3537ef5b85b4c7dabed2676d4b72214c69c494"
+  public static let revision = "d1972add2a63b2a528a6471d447f82e0010b5215"
 
   /// WebRTC フレームワークのソースコードのリビジョン (短縮版)
   public static var shortRevision: String {


### PR DESCRIPTION
## 概要
- libwebrtc を m146.7680.0.1 に更新する
- PackageInfo の WebRTC 情報を更新する
- README と CHANGES の libwebrtc 表記を更新する

## 確認内容
- xcodebuild -scheme 'Sora' -sdk iphoneos26.2 -configuration Release -derivedDataPath build -destination 'generic/platform=iOS' clean build CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= PROVISIONING_PROFILE=
