### PR TITLE
TURN-TLS の証明書検証で iOS の CA を利用する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
   - @zztkm
 - [UPDATE] TURN-TLS の証明書検証で iOS の CA を利用する
   - `RTCSSLCertificateVerifier.verifyChain` を利用して証明書チェーン全体を取得し、 Security フレームワークで検証する
-  - TURN-TLS の ICE サーバー設定を `offer.configuration` で受け取った後に main の `RTCPeerConnection` を生成する
+  - `offer.configuration` で TURN-TLS の ICE サーバー設定を受け取った後に、接続に利用する `RTCPeerConnection` を生成する
   - @zztkm
 - [UPDATE] libwebrtc m146.7680.0.1 に上げる
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,8 +27,6 @@
   - `RTCSSLCertificateVerifier.verifyChain` を利用して証明書チェーン全体を取得し、 Security フレームワークで検証する
   - `offer.configuration` で TURN-TLS の ICE サーバー設定を受け取った後に、接続に利用する `RTCPeerConnection` を生成する
   - @zztkm
-- [UPDATE] libwebrtc m146.7680.0.1 に上げる
-  - @zztkm
 - [UPDATE] 静的共有状態と singleton を Swift 6 の concurrency-safe 要件に対応させる
   - `CameraVideoCapturer`, `Logger`, `NativePeerChannelFactory`, `Sora` などの共有状態を整理する
   - `MediaStream` のダミー capturer と `MediaChannelConfiguration.maxBitRate` の共有状態を見直す

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
   - @zztkm
 - [UPDATE] TURN-TLS の証明書検証で iOS の CA を利用する
   - `RTCSSLCertificateVerifier.verifyChain` を利用して証明書チェーン全体を取得し、 Security フレームワークで検証する
+  - TURN-TLS の ICE サーバー設定を `offer.configuration` で受け取った後に main の `RTCPeerConnection` を生成する
   - @zztkm
 - [UPDATE] libwebrtc m146.7680.0.1 に上げる
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
     - PTS が無効な場合は単調時刻でフォールバックして間引く
   - 画面キャプチャには ReplayKit を利用する
   - @t-miya
+- [FIX] シグナリングチャンネル接続エラー時に `connect()` で取得したロックが解放されないバグを修正する
+  - `sendConnectMessage(error:)` のエラーパスで `lock.unlock()` が呼ばれていなかったため
+  - @zztkm
 - [FIX] `Sora.setAudioMode` で AudioMode が `.default` であれば入力経路のオーバーライドをリセットする
   - 入力経路を `.speaker` にオーバーライドした後に他モードを指定しても経路がリセットされなかったため
   - @t-miya

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
 - [UPDATE] `URLSessionWebSocketChannel` と `Proxy` を Swift 6 の `Sendable` 要件に対応させる
   - `URLSessionWebSocketChannel` を `final class` かつ `@unchecked Sendable` とし、 `Proxy` を `Sendable` に対応させる
   - @zztkm
+- [UPDATE] TURN-TLS の証明書検証で iOS の CA を利用する
+  - `RTCSSLCertificateVerifier.verifyChain` を利用して証明書チェーン全体を取得し、 Security フレームワークで検証する
+  - @zztkm
 - [UPDATE] libwebrtc m146.7680.0.1 に上げる
   - @zztkm
 - [ADD] MediaChannelHandlers にシグナリングメッセージを JSON 文字列として取得する `onReceiveSignalingJSON` を追加する

--- a/Sora/ICEServerInfo.swift
+++ b/Sora/ICEServerInfo.swift
@@ -42,7 +42,7 @@ public final class ICEServerInfo {
     self.tlsSecurityPolicy = tlsSecurityPolicy
   }
 
-  var usesSecureTURNTLS: Bool {
+  var usesVerifiedTURNTLS: Bool {
     switch tlsSecurityPolicy {
     case .secure:
       return urls.contains { url in

--- a/Sora/ICEServerInfo.swift
+++ b/Sora/ICEServerInfo.swift
@@ -41,6 +41,17 @@ public final class ICEServerInfo {
     self.credential = credential
     self.tlsSecurityPolicy = tlsSecurityPolicy
   }
+
+  var usesSecureTURNTLS: Bool {
+    switch tlsSecurityPolicy {
+    case .secure:
+      return urls.contains { url in
+        url.lowercased().hasPrefix("turns:")
+      }
+    case .insecure:
+      return false
+    }
+  }
 }
 
 /// :nodoc:

--- a/Sora/IOSCertificateVerifier.swift
+++ b/Sora/IOSCertificateVerifier.swift
@@ -2,6 +2,7 @@ import Foundation
 import Security
 import WebRTC
 
+/// TURN-TLS 向けに iOS のシステム CA で証明書チェーンを検証する verifier です。
 final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
   typealias Evaluator = ([SecCertificate]) -> Bool
 
@@ -13,7 +14,7 @@ final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
   }
 
   // `RTCSSLCertificateVerifier` の必須要件を満たすために実装する。
-  // `verifyChain` が利用できる libwebrtc では、通常はこちらは使われない想定。
+  // `verifyChain` が利用できる場合こちらは使われない。
   func verify(_ derCertificate: Data) -> Bool {
     return verifyChain([derCertificate])
   }

--- a/Sora/IOSCertificateVerifier.swift
+++ b/Sora/IOSCertificateVerifier.swift
@@ -18,6 +18,7 @@ final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
     return verifyChain([derCertificate])
   }
 
+  // libwebrtc 側から Objective-C の `verifyChain:` selector として呼べるように `@objc` を付与する。
   @objc func verifyChain(_ derCertificateChain: [Data]) -> Bool {
     let certificateChain = derCertificateChain.compactMap { derCertificate in
       SecCertificateCreateWithData(nil, derCertificate as CFData)

--- a/Sora/IOSCertificateVerifier.swift
+++ b/Sora/IOSCertificateVerifier.swift
@@ -15,7 +15,7 @@ final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
   // `RTCSSLCertificateVerifier` の必須要件を満たすために実装する。
   // `verifyChain` が利用できる libwebrtc では、通常はこちらは使われない想定。
   func verify(_ derCertificate: Data) -> Bool {
-    verifyChain([derCertificate])
+    return verifyChain([derCertificate])
   }
 
   @objc func verifyChain(_ derCertificateChain: [Data]) -> Bool {
@@ -46,6 +46,7 @@ final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
       return false
     }
 
-    return SecTrustEvaluateWithError(trust, nil)
+    var error: CFError?
+    return SecTrustEvaluateWithError(trust, &error)
   }
 }

--- a/Sora/IOSCertificateVerifier.swift
+++ b/Sora/IOSCertificateVerifier.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Security
+import WebRTC
+
+final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
+  typealias Evaluator = ([SecCertificate]) -> Bool
+
+  private let evaluator: Evaluator
+
+  init(evaluator: @escaping Evaluator = IOSCertificateVerifier.evaluate) {
+    self.evaluator = evaluator
+    super.init()
+  }
+
+  // `RTCSSLCertificateVerifier` の必須要件を満たすために実装する。
+  // `verifyChain` が利用できる libwebrtc では、通常はこちらは使われない想定。
+  func verify(_ derCertificate: Data) -> Bool {
+    verifyChain([derCertificate])
+  }
+
+  @objc func verifyChain(_ derCertificateChain: [Data]) -> Bool {
+    let certificateChain = derCertificateChain.compactMap { derCertificate in
+      SecCertificateCreateWithData(nil, derCertificate as CFData)
+    }
+
+    guard !certificateChain.isEmpty else {
+      return false
+    }
+
+    guard certificateChain.count == derCertificateChain.count else {
+      return false
+    }
+
+    return evaluator(certificateChain)
+  }
+
+  private static func evaluate(_ certificateChain: [SecCertificate]) -> Bool {
+    let policy = SecPolicyCreateSSL(false, nil)
+    var trust: SecTrust?
+    let status = SecTrustCreateWithCertificates(
+      certificateChain as CFArray,
+      policy,
+      &trust)
+
+    guard status == errSecSuccess, let trust else {
+      return false
+    }
+
+    return SecTrustEvaluateWithError(trust, nil)
+  }
+}

--- a/Sora/IOSCertificateVerifier.swift
+++ b/Sora/IOSCertificateVerifier.swift
@@ -35,7 +35,14 @@ final class IOSCertificateVerifier: NSObject, RTCSSLCertificateVerifier {
   }
 
   private static func evaluate(_ certificateChain: [SecCertificate]) -> Bool {
-    let policy = SecPolicyCreateSSL(false, nil)
+    // TURN サーバーの証明書をサーバー用途として検証する。
+    // ただし、 RTCSSLCertificateVerifier からは接続先ホスト名を受け取れないため、
+    // serverName を指定したホスト名検証は行えない。
+    // libwebrtc の TURN-TLS 向け OpenSSLAdapter 経路でも、ホスト名は SNI には使われるが、
+    // 証明書の SAN / CN 照合には使われていない。
+    // そのため、ここでは libwebrtc の既存挙動に合わせて、
+    // iOS のシステム CA による証明書チェーン検証のみを行う。
+    let policy = SecPolicyCreateSSL(true, nil)
     var trust: SecTrust?
     let status = SecTrustCreateWithCertificates(
       certificateChain as CFArray,

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -110,7 +110,7 @@ final class NativePeerChannelFactory: @unchecked Sendable {
   private func createCertificateVerifier(
     configuration: WebRTCConfiguration
   ) -> RTCSSLCertificateVerifier? {
-    if configuration.usesSecureTURNTLS {
+    if configuration.usesVerifiedTURNTLS {
       return IOSCertificateVerifier()
     }
 

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -72,11 +72,12 @@ class NativePeerChannelFactory {
     proxy: Proxy? = nil,
     delegate: RTCPeerConnectionDelegate?
   ) -> RTCPeerConnection? {
+    let certificateVerifier = createCertificateVerifier(configuration: configuration)
     if let proxy {
       return nativeFactory.peerConnection(
         with: configuration.nativeValue,
         constraints: constraints.nativeValue,
-        certificateVerifier: nil,
+        certificateVerifier: certificateVerifier,
         delegate: delegate,
         proxyType: RTCProxyType.https,
         proxyAgent: proxy.agent,
@@ -85,10 +86,29 @@ class NativePeerChannelFactory {
         proxyUsername: proxy.username ?? "",
         proxyPassword: proxy.password ?? "")
     } else {
-      return nativeFactory.peerConnection(
-        with: configuration.nativeValue, constraints: constraints.nativeValue,
-        delegate: delegate)
+      if let certificateVerifier {
+        return nativeFactory.peerConnection(
+          with: configuration.nativeValue,
+          constraints: constraints.nativeValue,
+          certificateVerifier: certificateVerifier,
+          delegate: delegate)
+      } else {
+        return nativeFactory.peerConnection(
+          with: configuration.nativeValue,
+          constraints: constraints.nativeValue,
+          delegate: delegate)
+      }
     }
+  }
+
+  func createCertificateVerifier(
+    configuration: WebRTCConfiguration
+  ) -> RTCSSLCertificateVerifier? {
+    if configuration.usesSecureTURNTLS {
+      return IOSCertificateVerifier()
+    }
+
+    return nil
   }
 
   func createNativeStream(streamId: String) -> RTCMediaStream {

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -76,6 +76,8 @@ final class NativePeerChannelFactory: @unchecked Sendable {
   ) -> RTCPeerConnection? {
     let certificateVerifier = createCertificateVerifier(configuration: configuration)
     if let proxy {
+      // proxy ありの overload は certificateVerifier が nullable のため、
+      // verifier が不要な場合は nil をそのまま渡せる。
       return nativeFactory.peerConnection(
         with: configuration.nativeValue,
         constraints: constraints.nativeValue,
@@ -95,6 +97,8 @@ final class NativePeerChannelFactory: @unchecked Sendable {
           certificateVerifier: certificateVerifier,
           delegate: delegate)
       } else {
+        // proxy なしの certificateVerifier 付き overload は nullable ではないため、
+        // certificateVerifier が不要な場合は certificateVerifier なしの overload を使う。
         return nativeFactory.peerConnection(
           with: configuration.nativeValue,
           constraints: constraints.nativeValue,

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -107,7 +107,7 @@ final class NativePeerChannelFactory: @unchecked Sendable {
     }
   }
 
-  func createCertificateVerifier(
+  private func createCertificateVerifier(
     configuration: WebRTCConfiguration
   ) -> RTCSSLCertificateVerifier? {
     if configuration.usesSecureTURNTLS {

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -780,7 +780,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     if nativeChannel == nil {
       // offer.configuration で ICE サーバー設定を受け取った後に NativePeerChannel を
       // 生成することで TURN-TLS 向けの certificateVerifier を正しく設定する。
-      nativeChannel = nativePeerChannelFactory
+      nativeChannel =
+        nativePeerChannelFactory
         .createNativePeerChannel(
           configuration: webRTCConfiguration,
           constraints: webRTCConfiguration.constraints,

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -786,8 +786,6 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         constraints: webRTCConfiguration.constraints,
         proxy: configuration.proxy,
         delegate: self)
-    nativeChannel?.setConfiguration(webRTCConfiguration.nativeValue)
-
     guard nativeChannel != nil else {
       // connect() で取得した初期ロックをここで解放しないと、
       // disconnect が defer されたままになってしまう。
@@ -797,6 +795,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         reason: .signalingFailure)
       return
     }
+    nativeChannel?.setConfiguration(webRTCConfiguration.nativeValue)
 
     lock.lock()
     createAnswer(

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -750,9 +750,6 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     offerEncodings = offer.encodings
 
     if let config = offer.configuration {
-      let usesSecureTURNTLS = config.iceServerInfos.contains { info in
-        info.usesSecureTURNTLS
-      }
       Logger.debug(type: .peerChannel, message: "update configuration")
       Logger.debug(
         type: .peerChannel, message: "ICE server infos => \(config.iceServerInfos)")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -133,11 +133,24 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
   weak var mediaChannel: MediaChannel?
 
   var state: PeerChannelConnectionState {
-    guard let nativeChannel else {
-      return PeerChannelConnectionState(RTCPeerConnectionState.new)
+    if let nativeChannel {
+      let state = PeerChannelConnectionState(nativeChannel.connectionState)
+      // connect() 開始後から finishConnecting() / basicDisconnect() までは onConnect が保持される。
+      // そのため、 RTCPeerConnection を生成済みでも connectionState が .new の間は
+      // 接続試行中として扱う。
+      if onConnect != nil, state == .new {
+        return .connecting
+      }
+      return state
     }
 
-    return PeerChannelConnectionState(nativeChannel.connectionState)
+    if onConnect != nil {
+      // offer.configuration を受け取るまで RTCPeerConnection を生成しないため、
+      // nativeChannel が未生成でも、onConnect が保持されていれば接続試行中として扱う。
+      return .connecting
+    }
+
+    return PeerChannelConnectionState(RTCPeerConnectionState.new)
   }
 
   var nativeChannel: RTCPeerConnection?
@@ -265,6 +278,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
   private func sendConnectMessage(error: Error?) {
     if let error {
+      lock.unlock()
       Logger.error(
         type: .peerChannel,
         message: "failed connecting to signaling channel (\(error.localizedDescription))")

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -773,6 +773,9 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     }
 
     guard nativeChannel != nil else {
+      // connect() で取得した初期ロックをここで解放しないと、
+      // disconnect が defer されたままになってしまう。
+      lock.unlock()
       disconnect(
         error: SoraError.peerChannelError(reason: "createNativePeerChannel failed"),
         reason: .signalingFailure)

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -217,6 +217,10 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       return
     }
 
+    Logger.debug(type: .peerChannel, message: "try connecting")
+    // このロックは finishConnecting() で解除される
+    lock.lock()
+
     onConnect = handler
 
     // TODO(zztkm): WrapperVideoEncoderFactory は type: offer メッセージを受け取ったときに設定されるので、ここでの設定は不要かもしれない
@@ -773,23 +777,16 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       webRTCConfiguration.iceTransportPolicy = config.iceTransportPolicy
     }
 
-    Logger.debug(type: .peerChannel, message: "try connecting")
-    // このロックは finishConnecting() で解除される
-    lock.lock()
-
-    if nativeChannel == nil {
-      // offer.configuration で ICE サーバー設定を受け取った後に NativePeerChannel を
-      // 生成することで TURN-TLS 向けの certificateVerifier を正しく設定する。
-      nativeChannel =
-        nativePeerChannelFactory
-        .createNativePeerChannel(
-          configuration: webRTCConfiguration,
-          constraints: webRTCConfiguration.constraints,
-          proxy: configuration.proxy,
-          delegate: self)
-    } else if offer.configuration != nil {
-      nativeChannel?.setConfiguration(webRTCConfiguration.nativeValue)
-    }
+    // offer.configuration で ICE サーバー設定を受け取った後に NativePeerChannel を
+    // 生成することで TURN-TLS 向けの certificateVerifier を正しく設定する。
+    nativeChannel =
+      nativePeerChannelFactory
+      .createNativePeerChannel(
+        configuration: webRTCConfiguration,
+        constraints: webRTCConfiguration.constraints,
+        proxy: configuration.proxy,
+        delegate: self)
+    nativeChannel?.setConfiguration(webRTCConfiguration.nativeValue)
 
     guard nativeChannel != nil else {
       // connect() で取得した初期ロックをここで解放しないと、

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -203,19 +203,6 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
     Logger.debug(type: .peerChannel, message: "try connecting")
 
-    nativeChannel = NativePeerChannelFactory.default
-      .createNativePeerChannel(
-        configuration: webRTCConfiguration,
-        constraints: webRTCConfiguration.constraints,
-        proxy: configuration.proxy,
-        delegate: self)
-    guard nativeChannel != nil else {
-      let message = "createNativePeerChannel failed"
-      Logger.debug(type: .peerChannel, message: message)
-      handler(SoraError.peerChannelError(reason: message))
-      return
-    }
-
     // このロックは finishConnecting() で解除される
     lock.lock()
     onConnect = handler
@@ -759,15 +746,13 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
   }
 
   private func createAndSendAnswer(offer: SignalingOffer) {
-    guard let nativeChannel else {
-      Logger.debug(type: .peerChannel, message: "nativeChannel should not be nil")
-      return
-    }
-
     Logger.debug(type: .peerChannel, message: "try sending answer")
     offerEncodings = offer.encodings
 
     if let config = offer.configuration {
+      let usesSecureTURNTLS = config.iceServerInfos.contains { info in
+        info.usesSecureTURNTLS
+      }
       Logger.debug(type: .peerChannel, message: "update configuration")
       Logger.debug(
         type: .peerChannel, message: "ICE server infos => \(config.iceServerInfos)")
@@ -775,7 +760,24 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         type: .peerChannel, message: "ICE transport policy => \(config.iceTransportPolicy)")
       webRTCConfiguration.iceServerInfos = config.iceServerInfos
       webRTCConfiguration.iceTransportPolicy = config.iceTransportPolicy
-      nativeChannel.setConfiguration(webRTCConfiguration.nativeValue)
+    }
+
+    if nativeChannel == nil {
+      nativeChannel = NativePeerChannelFactory.default
+        .createNativePeerChannel(
+          configuration: webRTCConfiguration,
+          constraints: webRTCConfiguration.constraints,
+          proxy: configuration.proxy,
+          delegate: self)
+    } else if offer.configuration != nil {
+      nativeChannel?.setConfiguration(webRTCConfiguration.nativeValue)
+    }
+
+    guard nativeChannel != nil else {
+      disconnect(
+        error: SoraError.peerChannelError(reason: "createNativePeerChannel failed"),
+        reason: .signalingFailure)
+      return
     }
 
     lock.lock()

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -786,7 +786,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         constraints: webRTCConfiguration.constraints,
         proxy: configuration.proxy,
         delegate: self)
-    guard nativeChannel != nil else {
+    guard let nativeChannel else {
       // connect() で取得した初期ロックをここで解放しないと、
       // disconnect が defer されたままになってしまう。
       lock.unlock()
@@ -795,7 +795,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
         reason: .signalingFailure)
       return
     }
-    nativeChannel?.setConfiguration(webRTCConfiguration.nativeValue)
+    nativeChannel.setConfiguration(webRTCConfiguration.nativeValue)
 
     lock.lock()
     createAnswer(

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -760,6 +760,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
     }
 
     if nativeChannel == nil {
+      // offer.configuration で ICE サーバー設定を受け取った後に NativePeerChannel を
+      // 生成することで TURN-TLS 向けの certificateVerifier を正しく設定する。
       nativeChannel = NativePeerChannelFactory.default
         .createNativePeerChannel(
           configuration: webRTCConfiguration,

--- a/Sora/WebRTCConfiguration.swift
+++ b/Sora/WebRTCConfiguration.swift
@@ -114,9 +114,9 @@ public struct WebRTCConfiguration {
 
   var nativeConstraints: RTCMediaConstraints { constraints.nativeValue }
 
-  var usesSecureTURNTLS: Bool {
+  var usesVerifiedTURNTLS: Bool {
     iceServerInfos.contains { info in
-      info.usesSecureTURNTLS
+      info.usesVerifiedTURNTLS
     }
   }
 }

--- a/Sora/WebRTCConfiguration.swift
+++ b/Sora/WebRTCConfiguration.swift
@@ -113,6 +113,12 @@ public struct WebRTCConfiguration {
   }
 
   var nativeConstraints: RTCMediaConstraints { constraints.nativeValue }
+
+  var usesSecureTURNTLS: Bool {
+    iceServerInfos.contains { info in
+      info.usesSecureTURNTLS
+    }
+  }
 }
 
 private let sdpSemanticsTable: PairTable<String, SDPSemantics> =


### PR DESCRIPTION
## 概要
- TURN-TLS の証明書検証で libwebrtc 内蔵の CA ではなく iOS の CA を利用する
- RTCSSLCertificateVerifier.verifyChain で証明書チェーン全体を受け取り Security フレームワークで検証する
- secure な turns のみ custom verifier を差し込む

## 変更内容
- IOSCertificateVerifier を追加する
- NativePeerChannelFactory で TURN-TLS 向けに certificateVerifier を設定する
- ICEServerInfo / WebRTCConfiguration に secure な turns 判定を追加する
- CHANGES.md を更新する

## 確認
- xcodebuild -scheme 'Sora-Package' -derivedDataPath build/turntls-dd-4 -sdk iphonesimulator26.2 -destination 'platform=iOS Simulator,id=0F65DAE7-5F3A-47CB-BC42-7E0E2E7CCC9D' test CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= PROVISIONING_PROFILE=