### PR TITLE
音声入力処理のバイパス設定を行う Configuration.bypassVoiceProcessing を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] `NativePeerChannelFactory` 接続単位で生成して利用するようにする
+  - 音声入力処理のバイパス追加に伴い、接続単位での管理が必要となったため
+  - @t-miya
 - [UPDATE] libwebrtc m146.7680.0.1 に上げる
   - @zztkm
 - [UPDATE] MediaChannelHandlers.onReceiveSignaling を非推奨にする
@@ -35,6 +38,9 @@
   - `MediaStream`, `MediaChannel`, `NativePeerChannelFactory` の非 `Sendable` な受け渡しを整理する
   - `NativePeerChannelFactory.createClientOfferSDP` の `offer` は `Task + async / await` では `passing closure as a 'sending' parameter risks causing data races` エラーになるため、コールバック形式へ変更する
   - @zztkm
+- [ADD] Configuration に接続時の音声入力処理のバイパスを設定する `bypassVoiceProcessing` を追加する
+  - `RTCAudioDeviceModule.initWithBypassVoiceProcessing(_:)` を接続単位で利用する
+  - @t-miya
 - [ADD] MediaChannelHandlers にシグナリングメッセージを JSON 文字列として取得する `onReceiveSignalingJSON` を追加する
   - @zztkm
 - [ADD] 音声ルート変更イベントとして `SoraHandlers.onChangeAudioRoute` を追加する

--- a/Sora/Configuration.swift
+++ b/Sora/Configuration.swift
@@ -148,6 +148,12 @@ public struct Configuration {
   /// 後から `MediaChannel.setAudioHardMute(false)` で必要に応じてマイクを有効にできます。
   public var initialMicrophoneEnabled: Bool = true
 
+  /// 接続時に iOS の Voice Processing をバイパスするかどうか。
+  ///
+  /// `true` の場合は、 Voice Processing を無効にした状態で ADM を生成します。
+  /// 接続中の動的変更には対応していません。
+  public var bypassVoiceProcessing: Bool = false
+
   /// サイマルキャストの可否。 `true` であればサイマルキャストを有効にします。
   public var simulcastEnabled: Bool = false
 

--- a/Sora/MediaChannel.swift
+++ b/Sora/MediaChannel.swift
@@ -210,6 +210,7 @@ public final class MediaChannel {
   private var _connectionTimer: ConnectionTimer?
 
   private let manager: Sora
+  private let nativePeerChannelFactory: NativePeerChannelFactory
 
   // 映像ハードミュートの同時呼び出しを直列化するための Actor です
   // MediaChannel 間の排他実行を保証するため static にしています
@@ -234,10 +235,13 @@ public final class MediaChannel {
   init(manager: Sora, configuration: Configuration) {
     self.manager = manager
     self.configuration = configuration
+    self.nativePeerChannelFactory = NativePeerChannelFactory(
+      bypassVoiceProcessing: configuration.bypassVoiceProcessing)
     signalingChannel = SignalingChannel.init(configuration: configuration)
     _peerChannel = PeerChannel.init(
       configuration: configuration,
       signalingChannel: signalingChannel,
+      nativePeerChannelFactory: nativePeerChannelFactory,
       mediaChannel: self)
     handlers = configuration.mediaChannelHandlers
 
@@ -671,7 +675,7 @@ public final class MediaChannel {
     }
 
     // 音声ハードミュートを切り替えます
-    if !NativePeerChannelFactory.default.audioDeviceModuleWrapper.setAudioHardMute(mute) {
+    if !self.nativePeerChannelFactory.audioDeviceModuleWrapper.setAudioHardMute(mute) {
       return SoraError.mediaChannelError(
         reason: "AudioDeviceModuleWrapper::setAudioHardMute failed")
     }

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -31,10 +31,9 @@ final class WrapperVideoEncoderFactory: NSObject, @unchecked Sendable, RTCVideoE
   }
 }
 
-// WebRTC のファクトリーを共有して扱うため、 @unchecked Sendable を付与します。
+// WebRTC の非 Sendable オブジェクトを保持するため、
+// 呼び出し側でスレッド安全性を担保する前提で @unchecked Sendable を付与します。
 final class NativePeerChannelFactory: @unchecked Sendable {
-  static let `default` = NativePeerChannelFactory()
-
   let audioDeviceModule: RTCAudioDeviceModule
   /// 録音ポーズ/再開制御用に保持する ADM ラッパー
   let audioDeviceModuleWrapper: AudioDeviceModuleWrapper

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -41,10 +41,10 @@ final class NativePeerChannelFactory: @unchecked Sendable {
 
   var nativeFactory: RTCPeerConnectionFactory
 
-  init() {
+  init(bypassVoiceProcessing: Bool = false) {
     Logger.debug(type: .peerChannel, message: "create native peer channel factory")
 
-    audioDeviceModule = RTCAudioDeviceModule()
+    audioDeviceModule = RTCAudioDeviceModule(bypassVoiceProcessing: bypassVoiceProcessing)
     audioDeviceModuleWrapper = AudioDeviceModuleWrapper(audioDeviceModule: audioDeviceModule)
 
     // 映像コーデックのエンコーダーとデコーダーを用意する

--- a/Sora/NativePeerChannelFactory.swift
+++ b/Sora/NativePeerChannelFactory.swift
@@ -40,7 +40,7 @@ final class NativePeerChannelFactory: @unchecked Sendable {
 
   var nativeFactory: RTCPeerConnectionFactory
 
-  init(bypassVoiceProcessing: Bool = false) {
+  init(bypassVoiceProcessing: Bool) {
     Logger.debug(type: .peerChannel, message: "create native peer channel factory")
 
     audioDeviceModule = RTCAudioDeviceModule(bypassVoiceProcessing: bypassVoiceProcessing)

--- a/Sora/PeerChannel.swift
+++ b/Sora/PeerChannel.swift
@@ -121,6 +121,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
   var internalHandlers = PeerChannelInternalHandlers()
   let configuration: Configuration
   let signalingChannel: SignalingChannel
+  let nativePeerChannelFactory: NativePeerChannelFactory
 
   private(set) var streams: [MediaStream] = []
   private(set) var iceCandidates: [ICECandidate] = []
@@ -168,11 +169,13 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
   required init(
     configuration: Configuration, signalingChannel: SignalingChannel,
+    nativePeerChannelFactory: NativePeerChannelFactory,
     mediaChannel: MediaChannel?
   ) {
     self.signalingChannel = signalingChannel
     self.mediaChannel = mediaChannel
     self.configuration = configuration
+    self.nativePeerChannelFactory = nativePeerChannelFactory
     webRTCConfiguration = configuration.webRTCConfiguration
 
     lock = Lock()
@@ -203,7 +206,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
     Logger.debug(type: .peerChannel, message: "try connecting")
 
-    nativeChannel = NativePeerChannelFactory.default
+    nativeChannel =
+      nativePeerChannelFactory
       .createNativePeerChannel(
         configuration: webRTCConfiguration,
         constraints: webRTCConfiguration.constraints,
@@ -288,7 +292,7 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
 
     if configuration.isSender {
       Logger.debug(type: .peerChannel, message: "try creating offer SDP")
-      NativePeerChannelFactory.default
+      nativePeerChannelFactory
         .createClientOfferSDP(
           configuration: webRTCConfiguration,
           constraints: webRTCConfiguration.constraints
@@ -390,7 +394,8 @@ class PeerChannel: NSObject, RTCPeerConnectionDelegate {
       type: .peerChannel,
       message: "initialize sender stream")
 
-    let nativeStream = NativePeerChannelFactory.default
+    let nativeStream =
+      nativePeerChannelFactory
       .createNativeSenderStream(
         streamId: configuration.publisherStreamId,
         videoTrackId:


### PR DESCRIPTION
- Configuration に `bypassVoiceProcessing` を追加し、`RTCAudioDeviceModule.initWithBypassVoiceProcessing(:BOOL)` による音声入力処理のバイパスをできるようにする
- バイパス設定を接続単位で切り替えられるように、NativePeerChannelFactory を共通インスタンスから、接続ごとに生成したインスタンス利用に変更する