### PR TITLE
0073 API ドキュメントを GitHub Pages で独立公開する

### DIFF
--- a/.github/workflows/deploy-apidoc.yml
+++ b/.github/workflows/deploy-apidoc.yml
@@ -1,0 +1,65 @@
+name: deploy-apidoc
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: macos-26
+    env:
+      XCODE: /Applications/Xcode_26.2.app
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Select Xcode Version
+      run: sudo xcode-select -s '${{ env.XCODE }}/Contents/Developer'
+    - name: Show Xcode Version
+      run: xcodebuild -version
+    - name: Install Jazzy
+      run: sudo gem install jazzy
+    - name: Generate API Documentation
+      run: jazzy
+    - name: Upload Pages Artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      with:
+        path: docs
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      id: deployment
+  slack_notify:
+    needs: [deploy]
+    runs-on: ubuntu-slim
+    # build が失敗して deploy が skipped になっても通知するため !cancelled() を指定する
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
+    steps:
+    - name: Slack Notification
+      uses: shiguredo/github-actions/.github/actions/slack-notify@main
+      with:
+        status: ${{ needs.deploy.result }}
+        slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+        slack_channel: sora-ios-sdk
+        # Pages デプロイの失敗と復旧を Fixed 通知で捉えるため failure_and_fixed を指定する
+        notify_mode: failure_and_fixed
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -3,7 +3,7 @@ author: Shiguredo Inc. and Masashi Ono (akisute)
 author_url: https://sora.shiguredo.jp/
 github_url: https://github.com/shiguredo/sora-ios-sdk/
 github_file_prefix: https://github.com/shiguredo/sora-ios-sdk/blob/master
-root_url: https://sora-ios-sdk.shiguredo.jp/
+root_url: https://shiguredo.github.io/sora-ios-sdk/
 theme: apple
 min_acl: public
 sdk: iphoneos

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,9 @@
 - [ADD] iOS E2E テストを self-hosted macOS runner で CI 実行できるようにする
   - ci.yml を追加し、recvonly 接続テストを iOS Simulator 上で実行する
   - @t-miya
+- [ADD] API ドキュメントを GitHub Pages で公開するワークフローを追加する
+  - deploy-apidoc.yml を追加し、Jazzy で生成した API ドキュメントを GitHub Pages にデプロイする
+  - @voluntas
 
 ## 2026.1.0
 

--- a/issues/closed/0073-add-deploy-apidoc-github-pages.md
+++ b/issues/closed/0073-add-deploy-apidoc-github-pages.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-26
-- Completed:
+- Completed: 2026-06-29
 - Model: Opus 4.7
 - Branch: feature/add-deploy-apidoc-github-pages
 - Polished: 2026-06-29
@@ -123,3 +123,18 @@ sora-js-sdk の `.github/workflows/deploy-apidoc.yml` を参考に、Jazzy + mac
 5. develop の変更を master に cherry-pick する
 6. GitHub Pages の `source.branch` を `master` に切り替える（`gh api` で実施）
 7. master への push で workflow が自動発火するので、`https://shiguredo.github.io/sora-ios-sdk/` の表示を確認する
+
+以下の対応を行った。
+
+- `.github/workflows/deploy-apidoc.yml` を新規作成し、Jazzy で生成した API ドキュメントを GitHub Pages にデプロイする workflow を追加した
+  - `build` ジョブ: `macos-26` runner で Jazzy をインストールし、API ドキュメントを `docs/` に生成して `actions/upload-pages-artifact` でアップロードする
+  - `deploy` ジョブ: `ubuntu-slim` runner で `actions/deploy-pages` を使って GitHub Pages にデプロイする
+  - `slack_notify` ジョブ: `ubuntu-slim` runner で `shiguredo/github-actions` の slack-notify を使い、`notify_mode: failure_and_fixed` で Pages デプロイの失敗と復旧を通知する
+- `.jazzy.yaml` の `root_url` を `https://sora-ios-sdk.shiguredo.jp/` から `https://shiguredo.github.io/sora-ios-sdk/` に変更した
+- `CHANGES.md` の `## develop` の `### misc` セクションに `[ADD]` エントリを追記した
+
+PR スコープ外の手動作業（マージ後に作業者が実施するもの）:
+
+- develop でマージした変更を master に cherry-pick する
+- GitHub Pages の `source.branch` を `master` に切り替える（`gh api` で実施）
+- master への cherry-pick push で workflow が自動発火し、`https://shiguredo.github.io/sora-ios-sdk/` に Jazzy 出力が配信されていることを確認する


### PR DESCRIPTION
## 概要

Jazzy で生成した API ドキュメントを GitHub Pages で独立公開するための workflow を追加し、メインドキュメントリポジトリへの手動コピー運用から CI 自動配信に移行する。

## 変更内容

- `.github/workflows/deploy-apidoc.yml` を追加し、Jazzy で生成した API ドキュメントを GitHub Pages にデプロイする workflow を構築する
  - `build` ジョブ: `macos-26` runner で Jazzy をインストールし、API ドキュメントを `docs/` に生成して `actions/upload-pages-artifact` でアップロードする
  - `deploy` ジョブ: `ubuntu-slim` runner で `actions/deploy-pages` を使って GitHub Pages にデプロイする
  - `slack_notify` ジョブ: `notify_mode: failure_and_fixed` で Pages デプロイの失敗と復旧を Slack 通知する
- `.jazzy.yaml` の `root_url` を `https://shiguredo.github.io/sora-ios-sdk/` に変更する
- `CHANGES.md` の `## develop` の `### misc` セクションに `[ADD]` エントリを追記する

## 完了条件

- [x] `.github/workflows/deploy-apidoc.yml` が追加されている
- [x] `.jazzy.yaml` の `root_url` が `https://shiguredo.github.io/sora-ios-sdk/` に更新されている
- [x] `CHANGES.md` の `## develop` の `### misc` セクションに `[ADD]` で本変更が追記されている

## マージ後の手動作業（PR スコープ外）

- develop でマージした変更を master に cherry-pick する
- GitHub Pages の `source.branch` を `master` に切り替える（`gh api` で実施）
- master への cherry-pick push で workflow が自動発火し、`https://shiguredo.github.io/sora-ios-sdk/` に Jazzy 出力が配信されていることを確認する

## 関連 issue

- issues/closed/0073-add-deploy-apidoc-github-pages.md